### PR TITLE
feat: add full Docker Compose stack and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,85 @@ The changes will then get merged to staging branch and then to master branch.
 
 Checkout the [Figma Design](https://www.figma.com/design/FwLnU97I8LjtYNREPyYofc/Olake%2FDesign%2FCommunity?m=auto&t=3T4OEwuQNOxoE3zm-1) for OLake frontend that is being developed, for you to get better sense and contribute to the issues we have created.
  
+## Running with Docker Compose
+
+You can run the entire Olake stack (UI, Backend, Temporal worker, Temporal services, and dependencies) using Docker Compose. This is the recommended way to get started for local development or evaluation.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed and running (Docker Desktop recommended for Mac/Windows)
+- [Docker Compose](https://docs.docker.com/compose/) (comes with Docker Desktop)
+
+### Configuration: `app.conf`
+
+You **must** provide an `app.conf` file with your backend configuration.  
+This file should be placed in the directory specified by the `app_config_path` variable in your `docker-compose.yml` (see the `x-app-defaults` section).
+
+**Example `app.conf`:**
+```ini
+appname = olake-server
+httpport = 8080
+runmode = dev
+copyrequestbody = true
+postgresdb = postgres://temporal:temporal@postgresql:5432/temporal
+logsdir = ./logger/logs
+sessionon = true
+TEMPORAL_ADDRESS=temporal:7233
+```
+
+### Quick Start
+
+1. **Clone the repository:**
+    ```bash
+    git clone https://github.com/datazip-inc/olake-app.git
+    cd olake-app
+    ```
+
+2. **Edit persistence/config paths (required):**
+    - By default, the `docker-compose.yml` uses `/Users/macos/temp` for persistent data and config.  
+      You can change this to any directory on your host by editing the `x-app-defaults` section at the top of `docker-compose.yml`:
+      ```yaml
+      x-app-defaults:
+        host_persistence_path: &hostPersistencePath /Users/macos/temp
+        app_config_path: &appConfigVolumeDetails    /Users/macos/temp
+      ```
+    - Make sure the directory exists and is writable.
+
+3. **Start all services:**
+    ```bash
+    docker compose up -d
+    ```
+
+4. **Check that everything is running:**
+    ```bash
+    docker compose ps
+    ```
+
+5. **Access the services:**
+    - **Frontend UI:** [http://localhost:5173](http://localhost:5173)
+    - **Backend API:** [http://localhost:8080](http://localhost:8080)
+    - **Temporal UI:** [http://localhost:8081](http://localhost:8081)
+
+6. **Stopping the stack:**
+    ```bash
+    docker compose down
+    ```
+
+### Notes
+
+- The first time you run, Docker will pull all required images.
+- Data and configuration are persisted in the directory you set in `docker-compose.yml`.
+- The Temporal worker requires access to the Docker socket to launch containers for jobs. This is handled by the volume mount in the compose file.
+
+### Troubleshooting
+
+- If you see errors about file permissions, ensure your host persistence/config directory is writable by Docker.
+- For more logs, use:
+    ```bash
+    docker-compose logs -f
+    ```
+- If you change the code or configuration, you may need to rebuild images:
+    ```bash
+    docker-compose build
+    docker-compose up -d
+    ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ appname = olake-server
 httpport = 8080
 runmode = dev
 copyrequestbody = true
-postgresdb = postgres://temporal:temporal@postgresql:5432/temporal
+postgresdb = postgres://temporal:temporal@postgresql:5432/postgres?sslmode=disable
 logsdir = ./logger/logs
 sessionon = true
 TEMPORAL_ADDRESS=temporal:7233

--- a/README.md
+++ b/README.md
@@ -20,24 +20,6 @@ You can run the entire Olake stack (UI, Backend, Temporal worker, Temporal servi
 - [Docker](https://docs.docker.com/get-docker/) installed and running (Docker Desktop recommended for Mac/Windows)
 - [Docker Compose](https://docs.docker.com/compose/) (comes with Docker Desktop)
 
-### Configuration: `app.conf`
-
-You **must** provide an `app.conf` file with your backend configuration.  
-This file should be placed in the directory specified by the `app_config_path` variable in your `docker-compose.yml` (see the `x-app-defaults` section).
-
-**Example `app.conf`:**
-
-```ini
-appname = olake-server
-httpport = 8080
-runmode = dev
-copyrequestbody = true
-postgresdb = postgres://temporal:temporal@postgresql:5432/postgres?sslmode=disable
-logsdir = ./logger/logs
-sessionon = true
-TEMPORAL_ADDRESS=temporal:7233
-```
-
 ### Quick Start
 
 1. **Clone the repository:**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can run the entire Olake stack (UI, Backend, Temporal worker, Temporal servi
 
 ### Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) installed and running (Docker Desktop recommended for Mac/Windows)
+- [Docker](https://docs.docker.com/get-docker/) installed (Docker Desktop recommended for Mac/Windows)
 - [Docker Compose](https://docs.docker.com/compose/) (comes with Docker Desktop)
 
 ### Quick Start
@@ -31,34 +31,47 @@ You can run the entire Olake stack (UI, Backend, Temporal worker, Temporal servi
 
 2. **Edit persistence/config paths (required):**
 
-   - By default, the `docker-compose.yml` uses `/Users/macos/temp` for persistent data and config.  
-     You can change this to any directory on your host by editing the `x-app-defaults` section at the top of `docker-compose.yml`:
+   - The docker-compose.yml uses `/your/chosen/host/path/olake-data` as a placeholder for the host directory where Olake's persistent data and configuration will be stored. You **must** replace this with an actual path on your system before starting the services. You can change this by editing the `x-app-defaults` section at the top of `docker-compose.yml`:
      ```yaml
      x-app-defaults:
-       host_persistence_path: &hostPersistencePath /Users/macos/temp
-       app_config_path: &appConfigVolumeDetails /Users/macos/temp
+       host_persistence_path: &hostPersistencePath /your/host/path
      ```
-   - Make sure the directory exists and is writable.
+   - Make sure the directory exists and is writable by the user running Docker (see how to change [file permissions for Linux/macOS](https://wiki.archlinux.org/title/File_permissions_and_attributes#Changing_permissions)).
 
-3. **Start all services:**
+3. **Customizing Admin User (optional):**
+
+   The stack automatically creates an initial admin user on first startup. The default credentials are:
+
+   - Username: "admin"
+   - Password: "password"
+   - Email: "test@example.com"
+
+   To change these defaults, edit the `x-signup-defaults` section in your `docker-compose.yml`:
+
+   ```yaml
+   x-signup-defaults:
+   username: &defaultUsername "your-custom-username"
+   password: &defaultPassword "your-secure-password"
+   email: &defaultEmail "your-email@example.com"
+   ```
+
+4. **Start all services:**
 
    ```bash
    docker compose up -d
    ```
 
-4. **Check that everything is running:**
+5. **Check that everything is running:**
 
    ```bash
    docker compose ps
    ```
 
-5. **Access the services:**
+6. **Access the services:**
 
-   - **Frontend UI:** [http://localhost:5173](http://localhost:5173)
-   - **Backend API:** [http://localhost:8080](http://localhost:8080)
-   - **Temporal UI:** [http://localhost:8081](http://localhost:8081)
+   - **Frontend UI:** [http://localhost:8000](http://localhost:8000)
 
-6. **Stopping the stack:**
+7. **Stopping the stack:**
    ```bash
    docker compose down
    ```
@@ -66,7 +79,7 @@ You can run the entire Olake stack (UI, Backend, Temporal worker, Temporal servi
 ### Notes
 
 - The first time you run, Docker will pull all required images.
-- Data and configuration are persisted in the directory you set in `docker-compose.yml`.
+- Data and configuration are persisted in the directory you set in `docker-compose.yml` at Step 2.
 - The Temporal worker requires access to the Docker socket to launch containers for jobs. This is handled by the volume mount in the compose file.
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # olake-frontend
+
 Frontend &amp; BFF (Backend for frontend) for Olake. This includes the UI code and backend code for storing the configuration of sync and orchestrating it.
 
 ## Contributing
-Checkout - [frontend initial setup branch](https://github.com/datazip-inc/olake-frontend/tree/feat/frontend_initial_setup_and_BFF) to see the work in progress and the related issues [here.](https://github.com/datazip-inc/olake-frontend/issues)
-Also checkout [CONTRIBUTING.MD](https://github.com/zriyanshdz/olake-frontend/blob/feat/frontend_initial_setup_and_BFF/olake_frontend/CONTRIBUTING.md) to get the guidelines.
 
+Checkout - [fix/refactor_bff_api branch](https://github.com/datazip-inc/olake-ui/tree/fix/refactor_bff_api) to see the current development work. This is the current branch for contributions and the related issues are [here.](https://github.com/datazip-inc/olake-frontend/issues)
+Also checkout [CONTRIBUTING.MD](https://github.com/datazip-inc/olake-ui/blob/fix/refactor_bff_api/CONTRIBUTING.md) to get the guidelines.
 
 The changes will then get merged to staging branch and then to master branch.
 
 Checkout the [Figma Design](https://www.figma.com/design/FwLnU97I8LjtYNREPyYofc/Olake%2FDesign%2FCommunity?m=auto&t=3T4OEwuQNOxoE3zm-1) for OLake frontend that is being developed, for you to get better sense and contribute to the issues we have created.
- 
+
 ## Running with Docker Compose
 
 You can run the entire Olake stack (UI, Backend, Temporal worker, Temporal services, and dependencies) using Docker Compose. This is the recommended way to get started for local development or evaluation.
@@ -25,6 +26,7 @@ You **must** provide an `app.conf` file with your backend configuration.
 This file should be placed in the directory specified by the `app_config_path` variable in your `docker-compose.yml` (see the `x-app-defaults` section).
 
 **Example `app.conf`:**
+
 ```ini
 appname = olake-server
 httpport = 8080
@@ -39,40 +41,45 @@ TEMPORAL_ADDRESS=temporal:7233
 ### Quick Start
 
 1. **Clone the repository:**
-    ```bash
-    git clone https://github.com/datazip-inc/olake-app.git
-    cd olake-app
-    ```
+
+   ```bash
+   git clone https://github.com/datazip-inc/olake-app.git
+   cd olake-app
+   ```
 
 2. **Edit persistence/config paths (required):**
-    - By default, the `docker-compose.yml` uses `/Users/macos/temp` for persistent data and config.  
-      You can change this to any directory on your host by editing the `x-app-defaults` section at the top of `docker-compose.yml`:
-      ```yaml
-      x-app-defaults:
-        host_persistence_path: &hostPersistencePath /Users/macos/temp
-        app_config_path: &appConfigVolumeDetails    /Users/macos/temp
-      ```
-    - Make sure the directory exists and is writable.
+
+   - By default, the `docker-compose.yml` uses `/Users/macos/temp` for persistent data and config.  
+     You can change this to any directory on your host by editing the `x-app-defaults` section at the top of `docker-compose.yml`:
+     ```yaml
+     x-app-defaults:
+       host_persistence_path: &hostPersistencePath /Users/macos/temp
+       app_config_path: &appConfigVolumeDetails /Users/macos/temp
+     ```
+   - Make sure the directory exists and is writable.
 
 3. **Start all services:**
-    ```bash
-    docker compose up -d
-    ```
+
+   ```bash
+   docker compose up -d
+   ```
 
 4. **Check that everything is running:**
-    ```bash
-    docker compose ps
-    ```
+
+   ```bash
+   docker compose ps
+   ```
 
 5. **Access the services:**
-    - **Frontend UI:** [http://localhost:5173](http://localhost:5173)
-    - **Backend API:** [http://localhost:8080](http://localhost:8080)
-    - **Temporal UI:** [http://localhost:8081](http://localhost:8081)
+
+   - **Frontend UI:** [http://localhost:5173](http://localhost:5173)
+   - **Backend API:** [http://localhost:8080](http://localhost:8080)
+   - **Temporal UI:** [http://localhost:8081](http://localhost:8081)
 
 6. **Stopping the stack:**
-    ```bash
-    docker compose down
-    ```
+   ```bash
+   docker compose down
+   ```
 
 ### Notes
 
@@ -84,11 +91,11 @@ TEMPORAL_ADDRESS=temporal:7233
 
 - If you see errors about file permissions, ensure your host persistence/config directory is writable by Docker.
 - For more logs, use:
-    ```bash
-    docker-compose logs -f
-    ```
+  ```bash
+  docker-compose logs -f
+  ```
 - If you change the code or configuration, you may need to rebuild images:
-    ```bash
-    docker-compose build
-    docker-compose up -d
-    ```
+  ```bash
+  docker-compose build
+  docker-compose up -d
+  ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Frontend &amp; BFF (Backend for frontend) for Olake. This includes the UI code a
 
 ## Contributing
 
-Checkout - [fix/refactor_bff_api branch](https://github.com/datazip-inc/olake-ui/tree/fix/refactor_bff_api) to see the current development work. This is the current branch for contributions and the related issues are [here.](https://github.com/datazip-inc/olake-frontend/issues)
-Also checkout [CONTRIBUTING.MD](https://github.com/datazip-inc/olake-ui/blob/fix/refactor_bff_api/CONTRIBUTING.md) to get the guidelines.
+Checkout - [frontend initial setup branch](https://github.com/datazip-inc/olake-frontend/tree/feat/frontend_initial_setup_and_BFF) to see the work in progress and the related issues [here.](https://github.com/datazip-inc/olake-frontend/issues)
+Also checkout [CONTRIBUTING.MD](https://github.com/zriyanshdz/olake-frontend/blob/feat/frontend_initial_setup_and_BFF/olake_frontend/CONTRIBUTING.md) to get the guidelines.
 
 The changes will then get merged to staging branch and then to master branch.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,5 @@
 x-app-defaults:
   host_persistence_path: &hostPersistencePath   /Users/macos/temp      # Edit this to your persistence directory
-  app_config_path: &appConfigVolumeDetails      /Users/macos/temp      # Edit this to your app config directory
-
-  app_config_volume_details: &appConfigPath
-    type: bind
-    source: *appConfigVolumeDetails
-    target: /opt/backend/conf
   worker_config_volume_details: &workerConfigVolumeDetails
     type: bind
     source: *hostPersistencePath
@@ -23,7 +17,6 @@ services:
       - "5173:5173"  # Expose UI port
       - "8080:8080"  # Expose backend API port
     volumes:
-      - <<: *appConfigPath
       - <<: *workerConfigVolumeDetails
     networks:
       - temporal-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,134 @@
+x-app-defaults:
+  host_persistence_path: &hostPersistencePath   /Users/macos/temp      # Edit this to your persistence directory
+  app_config_path: &appConfigVolumeDetails      /Users/macos/temp      # Edit this to your app config directory
+
+  app_config_volume_details: &appConfigPath
+    type: bind
+    source: *appConfigVolumeDetails
+    target: /opt/backend/conf
+  worker_config_volume_details: &workerConfigVolumeDetails
+    type: bind
+    source: *hostPersistencePath
+    target: /tmp/olake-config
+
+services:
+  olake-app:
+    image: olakego/ui:dev-latest
+    pull_policy: always
+    container_name: olake-app
+    environment:
+      PERSISTENT_DIR: *hostPersistencePath
+      POSTGRES_DB: "postgres://olake:olake@postgresql:5432/olakedb"
+    ports:
+      - "5173:5173"  # Expose UI port
+      - "8080:8080"  # Expose backend API port
+    volumes:
+      - <<: *appConfigPath
+      - <<: *workerConfigVolumeDetails
+    networks:
+      - temporal-network
+    depends_on:
+      - postgresql
+      - temporal
+    restart: unless-stopped
+
+  temporal-worker:
+    image: olakego/ui-worker:dev-latest
+    pull_policy: always
+    container_name: olake-temporal-worker
+    networks:
+      - temporal-network
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock # Mount Docker socket
+      - <<: *workerConfigVolumeDetails
+    environment:
+      TEMPORAL_ADDRESS: "temporal:7233"
+      PERSISTENT_DIR: *hostPersistencePath
+    depends_on:
+      - temporal
+      - olake-app
+    restart: unless-stopped
+
+  postgresql:
+    container_name: temporal-postgresql
+    image: postgres:13
+    environment:
+      POSTGRES_USER: temporal
+      POSTGRES_PASSWORD: temporal
+    networks:
+      - temporal-network
+    expose:
+      - 5432
+    ports:
+      - "5433:5432"  # Bind to all interfaces
+    volumes:
+      - temporal-postgresql-data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  temporal:
+    container_name: temporal
+    image: temporalio/auto-setup:1.22.3
+    depends_on:
+      - postgresql
+    environment:
+      - DB=postgres12 # This refers to the postgresql service type
+      - DB_PORT=5432
+      - POSTGRES_USER=temporal
+      - POSTGRES_PWD=temporal
+      - POSTGRES_SEEDS=postgresql # Service name of the postgres container
+      - ENABLE_ES=true
+      - ES_SEEDS=elasticsearch 
+      - ES_VERSION=v7 
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CLI_ADDRESS=temporal:7233
+    networks:
+      - temporal-network
+    ports:
+      - "7233:7233"  # Bind to all interfaces
+    restart: unless-stopped
+
+  temporal-ui:
+    container_name: temporal-ui
+    image: temporalio/ui:2.16.2
+    depends_on:
+      - temporal
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+    networks:
+      - temporal-network
+    ports:
+      - "8081:8080"  # Bind to all interfaces
+    restart: unless-stopped
+
+  elasticsearch:
+    container_name: temporal-elasticsearch
+    image: elasticsearch:7.17.10
+    environment:
+      - cluster.routing.allocation.disk.threshold_enabled=true
+      - cluster.routing.allocation.disk.watermark.low=512mb
+      - cluster.routing.allocation.disk.watermark.high=256mb
+      - cluster.routing.allocation.disk.watermark.flood_stage=128mb
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms256m -Xmx256m
+      - xpack.security.enabled=false
+    networks:
+      - temporal-network
+    expose:
+      - 9200
+    volumes:
+      - temporal-elasticsearch-data:/usr/share/elasticsearch/data
+    restart: unless-stopped
+
+networks:
+  temporal-network:
+    driver: bridge
+    name: temporal-network
+
+volumes:
+  temporal-postgresql-data:
+    driver: local
+  olake-config-data:
+    driver: local
+  temporal-elasticsearch-data:
+    driver: local
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 x-app-defaults:
-  host_persistence_path: &hostPersistencePath   /tmp/olake-config
+  host_persistence_path: &hostPersistencePath   /your/chosen/host/path/olake-data
   worker_config_volume_details: &workerConfigVolumeDetails
     type: bind
     source: *hostPersistencePath

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 x-app-defaults:
-  host_persistence_path: &hostPersistencePath   /Users/macos/temp      # Edit this to your persistence directory
+  host_persistence_path: &hostPersistencePath   /tmp/olake-config
   worker_config_volume_details: &workerConfigVolumeDetails
     type: bind
     source: *hostPersistencePath
     target: /tmp/olake-config
+
+x-signup-defaults:
+  username: &defaultUsername "admin"
+  password: &defaultPassword "password"
+  email: &defaultEmail "admin@example.com"
 
 services:
   olake-app:
@@ -14,16 +19,66 @@ services:
       PERSISTENT_DIR: *hostPersistencePath
       POSTGRES_DB: "postgres://olake:olake@postgresql:5432/olakedb"
     ports:
-      - "5173:5173"  # Expose UI port
+      - "8000:8000"  # Expose UI port
       - "8080:8080"  # Expose backend API port
     volumes:
       - <<: *workerConfigVolumeDetails
     networks:
       - temporal-network
     depends_on:
-      - postgresql
-      - temporal
+      postgresql:
+        condition: service_healthy # Wait for postgres to be healthy
+      temporal:
+        condition: service_started # Or service_healthy if temporal has a healthcheck
     restart: unless-stopped
+    healthcheck: # Updated healthcheck for olake-app
+      test: ["CMD-SHELL", "nc -z localhost 8080"] # Check if port 8080 is listening
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s # Give it time to start up before first health check
+
+  signup-init:
+    image: curlimages/curl:latest
+    container_name: olake-signup-init
+    networks:
+      - temporal-network
+    depends_on:
+      olake-app:
+        condition: service_healthy # Wait for olake-app to be healthy
+    environment:
+      USERNAME: *defaultUsername
+      PASSWORD: *defaultPassword
+      EMAIL: *defaultEmail
+      OLAKE_APP_URL: "http://olake-app:8080/signup"
+    command: >
+      sh -c "
+        echo 'signup-init: Initializing user setup...'
+        # The depends_on condition: service_healthy should handle the waiting for olake-app.
+
+        JSON_PAYLOAD=$$(printf '{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\"}' \"$${USERNAME}\" \"$${PASSWORD}\" \"$${EMAIL}\")
+        echo \"signup-init: Attempting to create user '$${USERNAME}' via $${OLAKE_APP_URL}\"
+
+        HTTP_RESPONSE_CODE=$$(/usr/bin/curl -s -o /dev/stderr -w '%{http_code}' -X POST -H 'Content-Type: application/json' -d \"$${JSON_PAYLOAD}\" \"$${OLAKE_APP_URL}\")
+
+        # The actual response body from olake-app will be printed to stderr by the '-o /dev/stderr' curl option.
+        # A newline after stderr output from curl can make logs cleaner.
+        echo '' 
+
+        if ! [ \"$${HTTP_RESPONSE_CODE}\" -eq \"$${HTTP_RESPONSE_CODE}\" ] 2>/dev/null; then
+            echo \"signup-init: ERROR - HTTP_RESPONSE_CODE is not a number: '$${HTTP_RESPONSE_CODE}'\"
+            exit 1;
+        fi
+
+        if [ \"$${HTTP_RESPONSE_CODE}\" -ge 200 ] && [ \"$${HTTP_RESPONSE_CODE}\" -lt 300 ]; then
+          echo \"signup-init: User '$${USERNAME}' creation request successful (HTTP $${HTTP_RESPONSE_CODE}).\";
+        else
+          echo \"signup-init: User '$${USERNAME}' creation request FAILED (HTTP $${HTTP_RESPONSE_CODE}). Server response body above.\";
+          exit 1; # Exit with error if signup failed
+        fi
+        echo 'signup-init: User setup process complete.';
+      "
+    restart: "no"
 
   temporal-worker:
     image: olakego/ui-worker:dev-latest
@@ -32,14 +87,16 @@ services:
     networks:
       - temporal-network
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock # Mount Docker socket
+      - /var/run/docker.sock:/var/run/docker.sock
       - <<: *workerConfigVolumeDetails
     environment:
       TEMPORAL_ADDRESS: "temporal:7233"
       PERSISTENT_DIR: *hostPersistencePath
     depends_on:
-      - temporal
-      - olake-app
+      temporal:
+        condition: service_started # Or service_healthy if temporal has a healthcheck
+      olake-app:
+        condition: service_healthy
     restart: unless-stopped
 
   postgresql:
@@ -53,44 +110,53 @@ services:
     expose:
       - 5432
     ports:
-      - "5433:5432"  # Bind to all interfaces
+      - "5433:5432"
     volumes:
       - temporal-postgresql-data:/var/lib/postgresql/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U temporal -h localhost -p 5432"] # Checks if server is accepting connections
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   temporal:
     container_name: temporal
     image: temporalio/auto-setup:1.22.3
     depends_on:
-      - postgresql
+      postgresql:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy # Wait for elasticsearch to be healthy
     environment:
-      - DB=postgres12 # This refers to the postgresql service type
+      - DB=postgres12
       - DB_PORT=5432
       - POSTGRES_USER=temporal
       - POSTGRES_PWD=temporal
-      - POSTGRES_SEEDS=postgresql # Service name of the postgres container
+      - POSTGRES_SEEDS=postgresql
       - ENABLE_ES=true
-      - ES_SEEDS=elasticsearch 
-      - ES_VERSION=v7 
+      - ES_SEEDS=elasticsearch
+      - ES_VERSION=v7
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_CLI_ADDRESS=temporal:7233
     networks:
       - temporal-network
     ports:
-      - "7233:7233"  # Bind to all interfaces
+      - "7233:7233"
     restart: unless-stopped
 
   temporal-ui:
     container_name: temporal-ui
     image: temporalio/ui:2.16.2
     depends_on:
-      - temporal
+      temporal:
+        condition: service_started
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
     networks:
       - temporal-network
     ports:
-      - "8081:8080"  # Bind to all interfaces
+      - "8081:8080"
     restart: unless-stopped
 
   elasticsearch:
@@ -111,6 +177,11 @@ services:
     volumes:
       - temporal-elasticsearch-data:/usr/share/elasticsearch/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
 networks:
   temporal-network:
@@ -124,4 +195,3 @@ volumes:
     driver: local
   temporal-elasticsearch-data:
     driver: local
-


### PR DESCRIPTION
- Added docker-compose.yml for running the entire Olake stack (UI, backend, Temporal worker, Temporal services, and dependencies) with a single command.
- Updated README.md with detailed "Running with Docker Compose" instructions, including configuration, prerequisites, and troubleshooting.
- Documented the requirement for a user-provided app.conf file and how to configure persistence paths.