### PR TITLE
fix: handled all edit flow cases 

### DIFF
--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -527,6 +527,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 							}
 							onFullLoadFilterChange={handleFullLoadFilterChange}
 							fromJobEditFlow={fromJobEditFlow}
+							initialSelectedStreams={apiResponse || undefined}
 						/>
 					) : (
 						!loading && (

--- a/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
@@ -5,6 +5,7 @@ import {
 	FilterOperator,
 	LogicalOperator,
 	MultiFilterCondition,
+	CombinedStreamsData,
 } from "../../../../types"
 import { Button, Divider, Input, Radio, Select, Switch, Tooltip } from "antd"
 import StreamsSchema from "./StreamsSchema"
@@ -31,6 +32,7 @@ const StreamConfiguration = ({
 	initialFullLoadFilter = "",
 	onFullLoadFilterChange,
 	fromJobEditFlow = false,
+	initialSelectedStreams,
 }: ExtendedStreamConfigurationProps) => {
 	const [activeTab, setActiveTab] = useState("config")
 	const [syncMode, setSyncMode] = useState(
@@ -65,6 +67,24 @@ const StreamConfiguration = ({
 		backfill: false,
 		partition_regex: initialPartitionRegex || "",
 	})
+
+	const [initialJobStreams, setInitialJobStreams] = useState<
+		CombinedStreamsData | undefined
+	>(undefined)
+
+	useEffect(() => {
+		// Set initial streams only once when component mounts
+		if (fromJobEditFlow && initialSelectedStreams && !initialJobStreams) {
+			setInitialJobStreams(initialSelectedStreams)
+		}
+	}, [fromJobEditFlow, initialSelectedStreams])
+
+	// Check if this stream was in the initial job streams
+	const isStreamInInitialSelection =
+		fromJobEditFlow &&
+		initialJobStreams?.selected_streams?.[stream.stream.namespace || ""]?.some(
+			(s: { stream_name: string }) => s.stream_name === stream.stream.name,
+		)
 
 	useEffect(() => {
 		setActiveTab("config")
@@ -681,7 +701,7 @@ const StreamConfiguration = ({
 							disabled={
 								syncMode === "full" ||
 								syncMode === "incremental" ||
-								fromJobEditFlow
+								isStreamInInitialSelection
 							}
 						/>
 					</div>
@@ -695,7 +715,7 @@ const StreamConfiguration = ({
 						<Switch
 							checked={normalisation}
 							onChange={handleNormalizationChange}
-							disabled={!isSelected || fromJobEditFlow}
+							disabled={!isSelected || isStreamInInitialSelection}
 						/>
 					</div>
 				</div>
@@ -714,7 +734,7 @@ const StreamConfiguration = ({
 						<Switch
 							checked={fullLoadFilter}
 							onChange={handleFullLoadFilterChange}
-							disabled={!isSelected || fromJobEditFlow}
+							disabled={!isSelected || isStreamInInitialSelection}
 						/>
 					</div>
 					{fullLoadFilter && isSelected && (
@@ -750,13 +770,13 @@ const StreamConfiguration = ({
 						className="w-full"
 						value={partitionRegex}
 						onChange={e => setPartitionRegex(e.target.value)}
-						disabled={!!activePartitionRegex || fromJobEditFlow}
+						disabled={!!activePartitionRegex || isStreamInInitialSelection}
 					/>
 					{!activePartitionRegex ? (
 						<Button
 							className="mt-2 w-fit bg-[#203FDD] px-1 py-3 font-light text-white"
 							onClick={handleSetPartitionRegex}
-							disabled={!partitionRegex}
+							disabled={!partitionRegex || isStreamInInitialSelection}
 						>
 							Set Partition
 						</Button>
@@ -773,7 +793,7 @@ const StreamConfiguration = ({
 									size="small"
 									className="rounded-[6px] py-1 text-sm"
 									onClick={handleClearPartitionRegex}
-									disabled={fromJobEditFlow}
+									disabled={isStreamInInitialSelection}
 								>
 									Delete Partition
 								</Button>
@@ -805,7 +825,7 @@ const StreamConfiguration = ({
 											? "bg-white text-gray-800 shadow-sm"
 											: "bg-transparent text-gray-600"
 									}`}
-									disabled={fromJobEditFlow}
+									disabled={isStreamInInitialSelection}
 								>
 									AND
 								</button>
@@ -817,7 +837,7 @@ const StreamConfiguration = ({
 											? "bg-white text-gray-800 shadow-sm"
 											: "bg-transparent text-gray-600"
 									}`}
-									disabled={fromJobEditFlow}
+									disabled={isStreamInInitialSelection}
 								>
 									OR
 								</button>
@@ -827,7 +847,7 @@ const StreamConfiguration = ({
 								danger
 								icon={<X className="size-4" />}
 								onClick={() => handleRemoveFilter(index)}
-								disabled={fromJobEditFlow}
+								disabled={isStreamInInitialSelection}
 							>
 								Remove
 							</Button>
@@ -861,7 +881,7 @@ const StreamConfiguration = ({
 								options={getColumnOptions()}
 								labelInValue={false}
 								optionLabelProp="value"
-								disabled={fromJobEditFlow}
+								disabled={isStreamInInitialSelection}
 							/>
 						</div>
 						<div>
@@ -876,7 +896,7 @@ const StreamConfiguration = ({
 									handleFilterConditionChange(index, "operator", value)
 								}
 								options={getFilteredOperatorOptions(condition.columnName)}
-								disabled={fromJobEditFlow}
+								disabled={isStreamInInitialSelection}
 							/>
 						</div>
 						<div>
@@ -887,18 +907,19 @@ const StreamConfiguration = ({
 								onChange={e =>
 									handleFilterConditionChange(index, "value", e.target.value)
 								}
-								disabled={fromJobEditFlow}
+								disabled={isStreamInInitialSelection}
 							/>
 						</div>
 					</div>
 				</div>
 			))}
-			{multiFilterCondition.conditions.length < 2 && !fromJobEditFlow && (
+			{multiFilterCondition.conditions.length < 2 && (
 				<Button
 					type="default"
 					icon={<Plus className="size-4" />}
 					onClick={handleAddFilter}
 					className="w-fit"
+					disabled={isStreamInInitialSelection}
 				>
 					New Column filter
 				</Button>

--- a/ui/src/types/streamTypes.ts
+++ b/ui/src/types/streamTypes.ts
@@ -129,6 +129,7 @@ export interface ExtendedStreamConfigurationProps
 	initialPartitionRegex: string
 	initialFullLoadFilter?: string
 	fromJobEditFlow?: boolean
+	initialSelectedStreams?: CombinedStreamsData
 	onNormalizationChange: (
 		streamName: string,
 		namespace: string,


### PR DESCRIPTION

- when a. new stream is selected in edit flow , it will have all edit options 
- if it is configured stream from creation , options will be disabled 
- sync mode , cursor field , incremental field will still be editable n all flows 

