### PR TITLE
fix: remove conflicting POSTGRES_DB from docker env 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     container_name: olake-ui
     environment:
       PERSISTENT_DIR: *hostPersistencePath
-      POSTGRES_DB: "postgres://olake:olake@postgresql:5432/olakedb"
       OLAKE_SECRET_KEY: *encryptionKey
     ports:
       - "8000:8000" # Single port: Go backend serves both API and frontend


### PR DESCRIPTION
# Description

 Remove duplicate POSTGRES_DB env from UI Docker Compose to avoid overriding DB configs, as it’s already defined in app.conf. This variable was unused in the UI setup.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
