### PR TITLE
fix: latest version issue

### DIFF
--- a/ui/src/api/services/destinationService.ts
+++ b/ui/src/api/services/destinationService.ts
@@ -126,6 +126,9 @@ export const destinationService = {
 	getDestinationVersions: async (type: string) => {
 		const response = await api.get<APIResponse<{ version: string[] }>>(
 			`${API_CONFIG.ENDPOINTS.DESTINATIONS(API_CONFIG.PROJECT_ID)}/versions/?type=${type}`,
+			{
+				timeout: 0,
+			},
 		)
 		return response.data
 	},

--- a/ui/src/api/services/destinationService.ts
+++ b/ui/src/api/services/destinationService.ts
@@ -146,7 +146,7 @@ export const destinationService = {
 			`${API_CONFIG.ENDPOINTS.DESTINATIONS(API_CONFIG.PROJECT_ID)}/spec`,
 			{
 				type: normalizedType,
-				version: version === "" ? "latest" : version,
+				version: version,
 				catalog: normalizedCatalog,
 			},
 		)

--- a/ui/src/api/services/sourceService.ts
+++ b/ui/src/api/services/sourceService.ts
@@ -138,7 +138,7 @@ export const sourceService = {
 					name,
 					type,
 					job_id: job_id ? job_id : -1,
-					version: version === "" ? "latest" : version,
+					version: version,
 					config,
 				},
 				{ timeout: 0 },

--- a/ui/src/api/services/sourceService.ts
+++ b/ui/src/api/services/sourceService.ts
@@ -100,6 +100,9 @@ export const sourceService = {
 		try {
 			const response = await api.get<APIResponse<{ version: string[] }>>(
 				`${API_CONFIG.ENDPOINTS.SOURCES(API_CONFIG.PROJECT_ID)}/versions/?type=${type}`,
+				{
+					timeout: 0,
+				},
 			)
 			return response.data
 		} catch (error) {

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -67,6 +67,15 @@ const CreateDestination = forwardRef<
 		},
 		ref,
 	) => {
+		const resetVersionState = () => {
+			setVersions([])
+			setVersion("")
+			setSchema(null)
+			if (onVersionChange) {
+				onVersionChange("")
+			}
+		}
+
 		const [setupType, setSetupType] = useState(SETUP_TYPES.NEW)
 		const [connector, setConnector] = useState<ConnectorType>(
 			initialConnector === undefined
@@ -235,14 +244,10 @@ const CreateDestination = forwardRef<
 							}
 						}
 					} else {
-						setVersions([])
-						setVersion("")
-						setSchema(null)
-						if (onVersionChange) {
-							onVersionChange("")
-						}
+						resetVersionState()
 					}
 				} catch (error) {
+					resetVersionState()
 					console.error("Error fetching versions:", error)
 				} finally {
 					setLoadingVersions(false)

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -224,8 +224,8 @@ const CreateDestination = forwardRef<
 					const response = await destinationService.getDestinationVersions(
 						connector.toLowerCase(),
 					)
-					if (response.data && response.data.version) {
-						const receivedVersions = response.data.version
+					if (response.data && response.data?.version) {
+						const receivedVersions = response.data?.version
 						setVersions(receivedVersions)
 						if (receivedVersions.length > 0) {
 							const defaultVersion = receivedVersions[0]

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -197,7 +197,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 					connectorType.toLowerCase(),
 				)
 
-				if (response.data && response.data.version) {
+				if (response.data && response.data?.version) {
 					setVersions(response.data.version)
 
 					// If no version is selected, set the first one as default

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react"
 import { useParams, Link, useNavigate } from "react-router-dom"
 import { Input, Button, Select, Switch, message, Spin, Table } from "antd"
 import { useAppStore } from "../../../store"
-import { ArrowLeft, Notebook } from "@phosphor-icons/react"
+import { ArrowLeft, Info, Notebook } from "@phosphor-icons/react"
 import DocumentationPanel from "../../common/components/DocumentationPanel"
 import FixedSchemaForm from "../../../utils/FormFix"
 import { destinationService } from "../../../api/services/destinationService"
@@ -46,7 +46,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 	const [catalog, setCatalog] = useState<string | null>(null)
 	const catalogName = "AWS Glue"
 	const [destinationName, setDestinationName] = useState("")
-	const [selectedVersion, setSelectedVersion] = useState("latest")
+	const [selectedVersion, setSelectedVersion] = useState("")
 	const [versions, setVersions] = useState<string[]>([])
 	const [loadingVersions, setLoadingVersions] = useState(false)
 	const [docsMinimized, setDocsMinimized] = useState(false)
@@ -155,7 +155,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 			// Only set connector if it's not already set or if it's the same as initialData
 			if (!connector || connector === connectorType) {
 				setConnector(connectorType)
-				setSelectedVersion(initialData.version || "latest")
+				setSelectedVersion(initialData.version || "")
 				if (initialData.config) {
 					let parsedConfig = initialData.config
 					if (typeof initialData.config === "string") {
@@ -206,6 +206,13 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 						if (onVersionChange) {
 							onVersionChange(response.data.version[0])
 						}
+					}
+				} else {
+					setVersions([])
+					setSelectedVersion("")
+					setSchema(null)
+					if (onVersionChange) {
+						onVersionChange("")
 					}
 				}
 			} catch (error) {
@@ -268,8 +275,9 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 				setIsLoading(false)
 			}
 		}
-
-		fetchDestinationSpec()
+		if (selectedVersion != "") {
+			fetchDestinationSpec()
+		}
 	}, [connector, selectedVersion, catalog])
 
 	const handleVersionChange = (value: string) => {
@@ -561,17 +569,24 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 							<label className="mb-2 block text-sm font-medium text-gray-700">
 								Version:
 							</label>
-							<Select
-								value={selectedVersion}
-								onChange={handleVersionChange}
-								className="w-full"
-								loading={loadingVersions}
-								placeholder="Select version"
-								options={versions.map(version => ({
-									value: version,
-									label: version,
-								}))}
-							/>
+							{versions.length > 0 ? (
+								<Select
+									value={selectedVersion}
+									onChange={handleVersionChange}
+									className="w-full"
+									loading={loadingVersions}
+									placeholder="Select version"
+									options={versions.map(version => ({
+										value: version,
+										label: version,
+									}))}
+								/>
+							) : (
+								<div className="flex items-center gap-1 text-sm text-red-500">
+									<Info />
+									No versions available
+								</div>
+							)}
 						</div>
 					</div>
 				</div>

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -206,7 +206,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 					connectorType.toLowerCase(),
 				)
 
-				if (response.data && response.data?.version) {
+				if (response.data?.version) {
 					setVersions(response.data.version)
 
 					// If no version is selected, set the first one as default
@@ -238,8 +238,14 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 	}, [connector])
 
 	useEffect(() => {
+		if (!selectedVersion || !connector) {
+			setSchema(null)
+			setUiSchema(null)
+			setFormData({})
+			return
+		}
+
 		const fetchDestinationSpec = async () => {
-			if (!connector) return
 			try {
 				setIsLoading(true)
 				const response = await destinationService.getDestinationSpec(
@@ -280,9 +286,8 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 				setIsLoading(false)
 			}
 		}
-		if (selectedVersion != "") {
-			fetchDestinationSpec()
-		}
+
+		fetchDestinationSpec()
 	}, [connector, selectedVersion, catalog])
 
 	const handleVersionChange = (value: string) => {
@@ -574,12 +579,15 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 							<label className="mb-2 block text-sm font-medium text-gray-700">
 								Version:
 							</label>
-							{versions.length > 0 ? (
+							{loadingVersions ? (
+								<div className="flex h-8 items-center justify-center">
+									<Spin size="small" />
+								</div>
+							) : versions.length > 0 ? (
 								<Select
 									value={selectedVersion}
 									onChange={handleVersionChange}
 									className="w-full"
-									loading={loadingVersions}
 									placeholder="Select version"
 									options={versions.map(version => ({
 										value: version,

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -180,6 +180,15 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 		}
 	}, [initialData])
 
+	const resetVersionState = () => {
+		setVersions([])
+		setSelectedVersion("")
+		setSchema(null)
+		if (onVersionChange) {
+			onVersionChange("")
+		}
+	}
+
 	useEffect(() => {
 		const fetchVersions = async () => {
 			if (!connector) return
@@ -208,14 +217,10 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 						}
 					}
 				} else {
-					setVersions([])
-					setSelectedVersion("")
-					setSchema(null)
-					if (onVersionChange) {
-						onVersionChange("")
-					}
+					resetVersionState()
 				}
 			} catch (error) {
+				resetVersionState()
 				console.error("Error fetching versions:", error)
 			} finally {
 				setLoadingVersions(false)

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -32,13 +32,13 @@ const JobCreation: React.FC = () => {
 	const [sourceName, setSourceName] = useState("")
 	const [sourceConnector, setSourceConnector] = useState("MongoDB")
 	const [sourceFormData, setSourceFormData] = useState<any>({})
-	const [sourceVersion, setSourceVersion] = useState("latest")
+	const [sourceVersion, setSourceVersion] = useState("")
 	const [destinationName, setDestinationName] = useState("")
 	const [destinationCatalogType, setDestinationCatalogType] =
 		useState<CatalogType | null>(null)
 	const [destinationConnector, setDestinationConnector] = useState("s3")
 	const [destinationFormData, setDestinationFormData] = useState<any>({})
-	const [destinationVersion, setDestinationVersion] = useState("latest")
+	const [destinationVersion, setDestinationVersion] = useState("")
 	const [selectedStreams, setSelectedStreams] = useState<any>([])
 	const [jobName, setJobName] = useState("")
 	const [cronExpression, setCronExpression] = useState("* * * * *")
@@ -63,11 +63,10 @@ const JobCreation: React.FC = () => {
 			if (sourceRef.current) {
 				const isValid = await sourceRef.current.validateSource()
 				if (!isValid) {
-					message.error("Please fill in all required fields for the source")
 					return
 				}
 			} else {
-				if (!sourceName.trim()) {
+				if (!sourceName.trim() && sourceVersion.trim() != "") {
 					message.error("Source name is required")
 					return
 				}
@@ -103,14 +102,11 @@ const JobCreation: React.FC = () => {
 			if (destinationRef.current) {
 				const isValid = await destinationRef.current.validateDestination()
 				if (!isValid) {
-					message.error(
-						"Please fill in all required fields for the destination",
-					)
 					return
 				}
 			} else {
 				// Fallback validation if ref isn't available
-				if (!destinationName.trim()) {
+				if (!destinationName.trim() && destinationVersion.trim() != "") {
 					message.error("Destination name is required")
 					return
 				}

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -213,7 +213,7 @@ const JobEdit: React.FC = () => {
 				database: "",
 				collection: "",
 			},
-			version: "latest",
+			version: "",
 		})
 
 		setDestinationData({
@@ -225,7 +225,7 @@ const JobEdit: React.FC = () => {
 				s3_region: "",
 				type: "PARQUET",
 			},
-			version: "latest",
+			version: "",
 		})
 
 		setJobName("New Job")
@@ -305,7 +305,7 @@ const JobEdit: React.FC = () => {
 					typeof sourceData?.config === "string"
 						? sourceData?.config
 						: JSON.stringify(sourceData?.config),
-				version: sourceData?.version || "latest",
+				version: sourceData?.version || "",
 			},
 			destination: {
 				name: destinationData?.name || "",
@@ -314,7 +314,7 @@ const JobEdit: React.FC = () => {
 					typeof destinationData?.config === "string"
 						? destinationData?.config
 						: JSON.stringify(destinationData?.config),
-				version: destinationData?.version || "latest",
+				version: destinationData?.version || "",
 			},
 			streams_config:
 				typeof selectedStreams === "string"
@@ -367,7 +367,7 @@ const JobEdit: React.FC = () => {
 					const testData = {
 						name: sourceData.name,
 						type: sourceData.type.toLowerCase(),
-						version: sourceData.version || "latest",
+						version: sourceData.version || "",
 						config:
 							typeof sourceData.config === "string"
 								? sourceData.config
@@ -403,7 +403,7 @@ const JobEdit: React.FC = () => {
 							typeof sourceData.config === "string"
 								? sourceData.config
 								: JSON.stringify(sourceData.config),
-						version: sourceData.version || "latest",
+						version: sourceData.version || "",
 					}
 					setShowTestingModal(true)
 					setIsFromSources(true)
@@ -431,7 +431,7 @@ const JobEdit: React.FC = () => {
 					const testData = {
 						name: destinationData.name,
 						type: destinationData.type.toLowerCase(),
-						version: destinationData.version || "latest",
+						version: destinationData.version || "",
 						config:
 							typeof destinationData.config === "string"
 								? destinationData.config
@@ -468,7 +468,7 @@ const JobEdit: React.FC = () => {
 							typeof destinationData.config === "string"
 								? destinationData.config
 								: JSON.stringify(destinationData.config),
-						version: destinationData.version || "latest",
+						version: destinationData.version || "",
 					}
 					setShowTestingModal(true)
 					setIsFromSources(false)
@@ -596,7 +596,7 @@ const JobEdit: React.FC = () => {
 									stepTitle="Streams Selection"
 									sourceName={sourceData?.name || ""}
 									sourceConnector={sourceData?.type.toLowerCase() || ""}
-									sourceVersion={sourceData?.version || "latest"}
+									sourceVersion={sourceData?.version || ""}
 									sourceConfig={JSON.stringify(sourceData?.config || {})}
 									fromJobEditFlow={true}
 									jobId={jobId ? parseInt(jobId) : -1}

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -98,6 +98,15 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 			}
 		}, [connector, setupType, fetchSources])
 
+		const resetVersionState = () => {
+			setVersions([])
+			setSelectedVersion("")
+			setSchema(null)
+			if (onVersionChange) {
+				onVersionChange("")
+			}
+		}
+
 		useEffect(() => {
 			if (
 				initialVersion &&
@@ -130,14 +139,10 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 							}
 						}
 					} else {
-						setVersions([])
-						setSelectedVersion("")
-						setSchema(null)
-						if (onVersionChange) {
-							onVersionChange("")
-						}
+						resetVersionState()
 					}
 				} catch (error) {
+					resetVersionState()
 					console.error("Error fetching versions:", error)
 				} finally {
 					setLoadingVersions(false)

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -115,7 +115,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 					const response = await sourceService.getSourceVersions(
 						connector.toLowerCase(),
 					)
-					if (response.data && response.data.version.length > 100) {
+					if (response.data && response.data?.version) {
 						setVersions(response.data.version)
 						if (
 							response.data.version.length > 0 &&

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -153,6 +153,15 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 		}
 	}, [connector, selectedVersion])
 
+	const resetVersionState = () => {
+		setAvailableVersions([])
+		setSelectedVersion("")
+		setSchema(null)
+		if (onVersionChange) {
+			onVersionChange("")
+		}
+	}
+
 	useEffect(() => {
 		const fetchVersions = async () => {
 			if (!connector) return
@@ -187,16 +196,11 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 						}
 					}
 				} else {
-					setAvailableVersions([])
-					setSelectedVersion("")
-					setSchema(null)
-					if (onVersionChange) {
-						onVersionChange("")
-					}
+					resetVersionState()
 				}
 			} catch (error) {
+				resetVersionState()
 				console.error("Error fetching versions:", error)
-				message.error("Failed to fetch versions")
 			}
 		}
 

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { useParams, useNavigate, Link } from "react-router-dom"
 import { Input, Button, Select, Switch, message, Table, Spin } from "antd"
-import { GenderNeuter, Notebook, ArrowLeft } from "@phosphor-icons/react"
+import { GenderNeuter, Notebook, ArrowLeft, Info } from "@phosphor-icons/react"
 import { useAppStore } from "../../../store"
 import type { ColumnsType } from "antd/es/table"
 import DocumentationPanel from "../../common/components/DocumentationPanel"
@@ -104,7 +104,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 			// Only set connector if it's not already set or if it's the same as initialData
 			if (!connector || connector === normalizedType) {
 				setConnector(normalizedType)
-				setSelectedVersion(initialData.version || "latest")
+				setSelectedVersion(initialData.version || "")
 
 				// Set form data from initialData only if connector matches
 				if (initialData.config) {
@@ -144,7 +144,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 			}
 		}
 
-		if (connector) {
+		if (connector && selectedVersion != "") {
 			fetchSourceSpec()
 		}
 
@@ -185,6 +185,13 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 								onVersionChange(initialData.version)
 							}
 						}
+					}
+				} else {
+					setAvailableVersions([])
+					setSelectedVersion("")
+					setSchema(null)
+					if (onVersionChange) {
+						onVersionChange("")
 					}
 				}
 			} catch (error) {
@@ -515,17 +522,24 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 											OLake Version:
 											<span className="text-red-500">*</span>
 										</label>
-										<Select
-											value={selectedVersion}
-											onChange={value => {
-												setSelectedVersion(value)
-												if (onVersionChange) {
-													onVersionChange(value)
-												}
-											}}
-											className="h-8 w-full"
-											options={availableVersions}
-										/>
+										{availableVersions.length > 0 ? (
+											<Select
+												value={selectedVersion}
+												onChange={value => {
+													setSelectedVersion(value)
+													if (onVersionChange) {
+														onVersionChange(value)
+													}
+												}}
+												className="h-8 w-full"
+												options={availableVersions}
+											/>
+										) : (
+											<div className="flex items-center gap-1 text-sm text-red-500">
+												<Info />
+												No versions available
+											</div>
+										)}
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
- removed latest fallback 
- when there is no version , showing no versions instead of dropdown and error when user try to create and edit
- don't call spec api when there is no version
- when there are no versions , and no name configured as well , showing only no valid version error (as per product request)