### PR TITLE
feat: add port mapping for Postgres for local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ BACKEND_ENV_VARS = \
       HTTP_PORT=8000 \
       RUN_MODE=localdev \
       COPY_REQUEST_BODY=true \
-      POSTGRES_DB=postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable \
+      POSTGRES_DB=postgres://temporal:temporal@localhost:5432/postgres?sslmode=disable \
       LOGS_DIR=./logger/logs \
       SESSION_ON=true \
       TEMPORAL_ADDRESS=localhost:7233 \
-	  CONTAINER_REGISTRY_BASE = registry-1.docker.io
+	  CONTAINER_REGISTRY_BASE=registry-1.docker.io
 
 # Frontend environment variables
 FRONTEND_ENV_VARS = \

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -25,8 +25,8 @@ services:
     image: postgres:13
     networks:
       - temporal-network
-    expose:
-      - 5432
+    ports:
+      - "5432:5432"
     volumes:
       - temporal-postgresql-data:/var/lib/postgresql/data
   temporal:


### PR DESCRIPTION
# Description

Enabled 5432:5432 port mapping so the backend can connect directly to the Temporal Postgres running in Docker.
This makes Temporal’s DB accessible both to host tools and backend services.
Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
