### PR TITLE
fix: segment removed, telemetry events directly sent to mixpanel

### DIFF
--- a/server/cmd/temporal-worker/main.go
+++ b/server/cmd/temporal-worker/main.go
@@ -65,6 +65,5 @@ func main() {
 
 	// Stop the worker
 	worker.Stop()
-	telemetry.Close()
 	logs.Info("Worker stopped. Goodbye!")
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.41.1
 	github.com/lib/pq v1.10.9
 	github.com/oklog/ulid v1.3.1
-	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/spf13/viper v1.20.1
 	go.temporal.io/sdk v1.34.0
 	golang.org/x/crypto v0.35.0

--- a/server/internal/telemetry/constants.go
+++ b/server/internal/telemetry/constants.go
@@ -8,7 +8,6 @@ const (
 	OlakeVersion             = "0.0.4"
 	IPNotFound               = "NA"
 	TelemetryConfigTimeout   = 5 * time.Second
-	TelemetryClientTimeout   = 5 * time.Second
 	ProxyTrackURL            = "https://analytics.olake.io/mp/track"
 	IPUrl                    = "https://api.ipify.org?format=text"
 	EventUserLogin           = "user_login"

--- a/server/internal/telemetry/constants.go
+++ b/server/internal/telemetry/constants.go
@@ -7,8 +7,9 @@ const (
 	TelemetryUserIDFile      = "user_id"
 	OlakeVersion             = "0.0.4"
 	IPNotFound               = "NA"
-	TelemetryConfigTimeout   = 30 * time.Second
-	TelemetrySegmentAPIKey   = "AiWKKeaOKQvsOotHj5iGANpNhYG6OaM3"
+	TelemetryConfigTimeout   = 5 * time.Second
+	TelemetryClientTimeout   = 5 * time.Second
+	ProxyTrackURL            = "https://analytics.olake.io/mp/track"
 	IPUrl                    = "https://api.ipify.org?format=text"
 	EventUserLogin           = "user_login"
 	EventJobCreated          = "job_created"

--- a/server/internal/telemetry/telemetry.go
+++ b/server/internal/telemetry/telemetry.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	// analytics "github.com/segmentio/analytics-go/v3"
 )
 
 var instance *Telemetry

--- a/server/internal/telemetry/telemetry.go
+++ b/server/internal/telemetry/telemetry.go
@@ -152,25 +152,30 @@ func TrackEvent(_ context.Context, eventName string, properties map[string]inter
 	if properties == nil {
 		properties = make(map[string]interface{})
 	}
-	properties["olake_version"] = instance.platform.OlakeVersion
-	properties["os"] = instance.platform.OS
-	properties["arch"] = instance.platform.Arch
-	properties["device_cpu"] = instance.platform.DeviceCPU
-	properties["ip_address"] = instance.ipAddress
-	properties["location"] = instance.locationInfo
-	properties["distinct_id"] = instance.TempUserID
-	properties["time"] = time.Now().Unix()
-	properties["event_original_name"] = eventName
-
 	// Add username to properties if available
 	if instance.username != "" {
 		properties["username"] = instance.username
+	}
+	props := map[string]interface{}{
+		"olake_version":       instance.platform.OlakeVersion,
+		"os":                  instance.platform.OS,
+		"arch":                instance.platform.Arch,
+		"device_cpu":          instance.platform.DeviceCPU,
+		"ip_address":          instance.ipAddress,
+		"location":            instance.locationInfo,
+		"distinct_id":         instance.TempUserID,
+		"time":                time.Now().Unix(),
+		"event_original_name": eventName,
+	}
+	for key, value := range props {
+		properties[key] = value
 	}
 
 	body := map[string]interface{}{
 		"event":      eventName,
 		"properties": properties,
 	}
+
 	propsBody, err := json.Marshal(body)
 	if err != nil {
 		return err

--- a/server/internal/telemetry/telemetry.go
+++ b/server/internal/telemetry/telemetry.go
@@ -71,7 +71,7 @@ func InitTelemetry() {
 		}()
 
 		instance = &Telemetry{
-			httpClient: &http.Client{Timeout: TelemetryClientTimeout},
+			httpClient: &http.Client{Timeout: TelemetryConfigTimeout},
 			platform: PlatformInfo{
 				OS:           runtime.GOOS,
 				Arch:         runtime.GOARCH,
@@ -144,7 +144,7 @@ func getLocationFromIP(ip string) *LocationInfo {
 }
 
 // TrackEvent sends a custom event to Segment
-func TrackEvent(_ context.Context, eventName string, properties map[string]interface{}) error {
+func TrackEvent(ctx context.Context, eventName string, properties map[string]interface{}) error {
 	if instance.httpClient == nil {
 		return fmt.Errorf("telemetry client is nil")
 	}
@@ -180,9 +180,6 @@ func TrackEvent(_ context.Context, eventName string, properties map[string]inter
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), TelemetryConfigTimeout)
-	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", ProxyTrackURL, strings.NewReader(string(propsBody)))
 	if err != nil {

--- a/server/main.go
+++ b/server/main.go
@@ -22,7 +22,6 @@ func main() {
 
 	// start telemetry service
 	telemetry.InitTelemetry()
-	defer telemetry.Close()
 
 	// check constants
 	constants.Init()


### PR DESCRIPTION
# Description
events sent directly to mixpanel, dependency on segment removed.



## Type of change


- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Discover and Sync CLI events were sent to mixpanel through cloudfare proxy.
