### PR TITLE
feat: forward all env vars from worker to activity container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,15 +13,19 @@ x-signup-defaults:
 x-encryption:
   key: &encryptionKey "" 
 
+x-envs:
+  shared: &sharedEnvs
+    CONTAINER_REGISTRY_BASE: ${CONTAINER_REGISTRY_BASE:-registry-1.docker.io}
+    OLAKE_SECRET_KEY: *encryptionKey
+    PERSISTENT_DIR: *hostPersistencePath
+
 services:
   olake-ui:
     image: ${CONTAINER_REGISTRY_BASE:-registry-1.docker.io}/olakego/ui:latest    
     pull_policy: always
     container_name: olake-ui
     environment:
-      CONTAINER_REGISTRY_BASE: ${CONTAINER_REGISTRY_BASE:-registry-1.docker.io}
-      PERSISTENT_DIR: *hostPersistencePath
-      OLAKE_SECRET_KEY: *encryptionKey
+      <<: *sharedEnvs
     ports:
       - "8000:8000" # Single port: Go backend serves both API and frontend
     volumes:
@@ -95,10 +99,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - <<: *workerConfigVolumeDetails
     environment:
-      CONTAINER_REGISTRY_BASE: ${CONTAINER_REGISTRY_BASE:-registry-1.docker.io}
-      TEMPORAL_ADDRESS: "temporal:7233"
-      OLAKE_SECRET_KEY: *encryptionKey
-      PERSISTENT_DIR: *hostPersistencePath
+      <<: *sharedEnvs
     depends_on:
       temporal:
         condition: service_started # Or service_healthy if temporal has a healthcheck

--- a/server/internal/docker/runner.go
+++ b/server/internal/docker/runner.go
@@ -151,6 +151,10 @@ func (r *Runner) buildDockerArgs(ctx context.Context, flag string, command Comma
 		dockerArgs = append(dockerArgs, "-v", fmt.Sprintf("%s:/mnt/config", hostOutputDir))
 	}
 
+	for key, value := range utils.GetWorkerEnvVars() {
+		dockerArgs = append(dockerArgs, "-e", fmt.Sprintf("%s=%s", key, value))
+	}
+
 	dockerArgs = append(dockerArgs, imageName, string(command))
 
 	if flag != "" {

--- a/server/utils/docker_utils.go
+++ b/server/utils/docker_utils.go
@@ -37,14 +37,17 @@ var defaultImages = []string{"olakego/source-mysql", "olakego/source-postgres", 
 
 // ignoredWorkerEnv is a map of environment variables that are ignored from the worker container.
 var ignoredWorkerEnv = map[string]any{ // A map is chosen because it gives O(1) lookup time for key existence.
-	"HOSTNAME":       nil,
-	"PATH":           nil,
-	"PWD":            nil,
-	"HOME":           nil,
-	"SHLVL":          nil,
-	"TERM":           nil,
-	"PERSISTENT_DIR": nil,
-	"_":              nil,
+	"HOSTNAME":                nil,
+	"PATH":                    nil,
+	"PWD":                     nil,
+	"HOME":                    nil,
+	"SHLVL":                   nil,
+	"TERM":                    nil,
+	"PERSISTENT_DIR":          nil,
+	"CONTAINER_REGISTRY_BASE": nil,
+	"TEMPORAL_ADDRESS":        nil,
+	"OLAKE_SECRET_KEY":        nil,
+	"_":                       nil,
 }
 
 // GetWorkerEnvVars returns the environment variables from the worker container.

--- a/server/utils/docker_utils.go
+++ b/server/utils/docker_utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 	"sort"
@@ -33,6 +34,32 @@ type DockerHubTagsResponse struct {
 }
 
 var defaultImages = []string{"olakego/source-mysql", "olakego/source-postgres", "olakego/source-oracle", "olakego/source-mongodb"}
+
+// ignoredWorkerEnv is a map of environment variables that are ignored from the worker container.
+var ignoredWorkerEnv = map[string]any{ // A map is chosen because it gives O(1) lookup time for key existence.
+	"HOSTNAME":       nil,
+	"PATH":           nil,
+	"PWD":            nil,
+	"HOME":           nil,
+	"SHLVL":          nil,
+	"TERM":           nil,
+	"PERSISTENT_DIR": nil,
+	"_":              nil,
+}
+
+// GetWorkerEnvVars returns the environment variables from the worker container.
+func GetWorkerEnvVars() map[string]string {
+	vars := make(map[string]string)
+	for _, entry := range os.Environ() {
+		parts := strings.SplitN(entry, "=", 2)
+		key := parts[0]
+		if _, ignore := ignoredWorkerEnv[key]; ignore {
+			continue
+		}
+		vars[key] = parts[1]
+	}
+	return vars
+}
 
 // GetDriverImageTags returns image tags from ECR or Docker Hub with fallback to cached images
 func GetDriverImageTags(ctx context.Context, imageName string, cachedTags bool) ([]string, string, error) {


### PR DESCRIPTION
# Description

This PR helps to forward all ENV variables from temporal-worker container to the activity containers(sync, spec, test etc)

Fixes: N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Backward compatibility test with prior version of temporal-worker(ui-worker)
2. Running on an EC2 machine with IAM role attached.

# Screenshots or Recordings
<img width="1627" height="202" alt="Screenshot 2025-09-19 at 1 20 17 PM" src="https://github.com/user-attachments/assets/69c29071-a76c-425e-939f-dcb4b03c7d40" />

## Related PR's (If Any): N/A
