### PR TITLE
fix: UI Issues P3

### DIFF
--- a/ui/src/modules/common/Modals/DestinationDatabaseModal.tsx
+++ b/ui/src/modules/common/Modals/DestinationDatabaseModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { Modal, Radio, Input, Button } from "antd"
+import { Modal, Radio, Input, Button, message } from "antd"
 import { useAppStore } from "../../../store"
 import { validateAlphanumericUnderscore } from "../../../utils/utils"
 import {
@@ -55,6 +55,12 @@ const DestinationDatabaseModal = ({
 	)
 
 	const handleSaveChanges = () => {
+		if (databaseName.trim() === "") {
+			message.error(
+				`${selectedFormat === FORMAT_OPTIONS.DYNAMIC ? `${labels.title} Prefix` : `${labels.title}`} can not be empty`,
+			)
+			return
+		}
 		onSave(selectedFormat, databaseName)
 		setShowDestinationDatabaseModal(false)
 	}

--- a/ui/src/modules/common/Modals/ResetStreamsModal.tsx
+++ b/ui/src/modules/common/Modals/ResetStreamsModal.tsx
@@ -1,8 +1,9 @@
-import { Warning } from "@phosphor-icons/react"
+import { FC } from "react"
+import { WarningIcon } from "@phosphor-icons/react"
 import { Button, Modal } from "antd"
+
 import { useAppStore } from "../../../store"
 import { ResetStreamsModalProps } from "../../../types"
-import { FC } from "react"
 
 const ResetStreamsModal: FC<ResetStreamsModalProps> = ({ onConfirm }) => {
 	const { showResetStreamsModal, setShowResetStreamsModal } = useAppStore()
@@ -23,28 +24,29 @@ const ResetStreamsModal: FC<ResetStreamsModalProps> = ({ onConfirm }) => {
 			centered
 			title={
 				<div className="flex items-center gap-2 text-danger">
-					<Warning
-						className="size-6"
+					<WarningIcon
+						className="size-9"
 						weight="fill"
 					/>
-					<span>Your changes will not be saved</span>
+					{/* <span>Your changes will not be saved</span> */}
 				</div>
 			}
 		>
 			<div className="flex flex-col items-center gap-6">
 				<div className="flex w-full flex-col">
-					<p className="font-medium text-slate-700">
-						Leaving this page will loose all your progress & changes
+					<p className="text-xl font-medium text-slate-700">
+						Your changes will not be saved
 					</p>
-					<p className="font-medium text-slate-700">
-						Are you sure want to leave?
+					<p className="text-sm text-slate-700">
+						Leaving this page will loose all your progress & changes.
 					</p>
+					<p className="mt-6">Are you sure you want to leave?</p>
 				</div>
 
 				<div className="flex w-full justify-end gap-3">
 					<Button
 						type="primary"
-						danger
+						className="!bg-[#f5222d]"
 						onClick={handleConfirm}
 					>
 						Yes, Leave

--- a/ui/src/modules/common/Modals/ResetStreamsModal.tsx
+++ b/ui/src/modules/common/Modals/ResetStreamsModal.tsx
@@ -27,26 +27,29 @@ const ResetStreamsModal: FC<ResetStreamsModalProps> = ({ onConfirm }) => {
 						className="size-6"
 						weight="fill"
 					/>
-					<span>Go back?</span>
+					<span>Your changes will not be saved</span>
 				</div>
 			}
 		>
 			<div className="flex flex-col items-center gap-6">
-				<p className="font-medium text-slate-700">
-					Going back will{" "}
-					<span className="font-semibold">reset all stream configurations</span>{" "}
-					and any changes will be lost.
-				</p>
+				<div className="flex w-full flex-col">
+					<p className="font-medium text-slate-700">
+						Leaving this page will loose all your progress & changes
+					</p>
+					<p className="font-medium text-slate-700">
+						Are you sure want to leave?
+					</p>
+				</div>
 
 				<div className="flex w-full justify-end gap-3">
-					<Button onClick={handleCancel}>Cancel</Button>
 					<Button
 						type="primary"
 						danger
 						onClick={handleConfirm}
 					>
-						Go Back
+						Yes, Leave
 					</Button>
+					<Button onClick={handleCancel}>No</Button>
 				</div>
 			</div>
 		</Modal>

--- a/ui/src/modules/common/Modals/ResetStreamsModal.tsx
+++ b/ui/src/modules/common/Modals/ResetStreamsModal.tsx
@@ -28,7 +28,6 @@ const ResetStreamsModal: FC<ResetStreamsModalProps> = ({ onConfirm }) => {
 						className="size-9"
 						weight="fill"
 					/>
-					{/* <span>Your changes will not be saved</span> */}
 				</div>
 			}
 		>

--- a/ui/src/modules/common/Modals/ResetStreamsModal.tsx
+++ b/ui/src/modules/common/Modals/ResetStreamsModal.tsx
@@ -1,0 +1,56 @@
+import { Warning } from "@phosphor-icons/react"
+import { Button, Modal } from "antd"
+import { useAppStore } from "../../../store"
+import { ResetStreamsModalProps } from "../../../types"
+import { FC } from "react"
+
+const ResetStreamsModal: FC<ResetStreamsModalProps> = ({ onConfirm }) => {
+	const { showResetStreamsModal, setShowResetStreamsModal } = useAppStore()
+
+	const handleCancel = () => setShowResetStreamsModal(false)
+
+	const handleConfirm = () => {
+		setShowResetStreamsModal(false)
+		onConfirm()
+	}
+
+	return (
+		<Modal
+			open={showResetStreamsModal}
+			onCancel={handleCancel}
+			footer={null}
+			closable={false}
+			centered
+			title={
+				<div className="flex items-center gap-2 text-danger">
+					<Warning
+						className="size-6"
+						weight="fill"
+					/>
+					<span>Go back?</span>
+				</div>
+			}
+		>
+			<div className="flex flex-col items-center gap-6">
+				<p className="font-medium text-slate-700">
+					Going back will{" "}
+					<span className="font-semibold">reset all stream configurations</span>{" "}
+					and any changes will be lost.
+				</p>
+
+				<div className="flex w-full justify-end gap-3">
+					<Button onClick={handleCancel}>Cancel</Button>
+					<Button
+						type="primary"
+						danger
+						onClick={handleConfirm}
+					>
+						Go Back
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	)
+}
+
+export default ResetStreamsModal

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -423,6 +423,9 @@ const CreateDestination = forwardRef<
 
 		const handleSetupTypeChange = (type: SetupType) => {
 			setSetupType(type)
+			setDestinationName("")
+			onDestinationNameChange?.("")
+
 			if (onDocsMinimizedChange) {
 				if (type === SETUP_TYPES.EXISTING) {
 					onDocsMinimizedChange(true)
@@ -432,13 +435,11 @@ const CreateDestination = forwardRef<
 			}
 			// Clear form data when switching to new destination
 			if (type === SETUP_TYPES.NEW) {
-				setDestinationName("")
 				setFormData({})
 				setSchema(null)
 				setConnector(CONNECTOR_TYPES.DESTINATION_DEFAULT_CONNECTOR) // Reset to default connector
 				setExistingDestination(null)
 				// Schema will be automatically fetched due to useEffect when connector changes
-				if (onDestinationNameChange) onDestinationNameChange("")
 				if (onConnectorChange) onConnectorChange(CONNECTOR_TYPES.AMAZON_S3)
 				if (onFormDataChange) onFormDataChange({})
 				if (onVersionChange) onVersionChange("")

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -412,11 +412,13 @@ const CreateDestination = forwardRef<
 			setVersion("")
 			setFormData({})
 			setSchema(null)
+			setDestinationName("")
 
 			// Parent callbacks
 			onConnectorChange?.(value)
 			onVersionChange?.("")
 			onFormDataChange?.({})
+			onDestinationNameChange?.("")
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -101,6 +101,9 @@ const CreateDestination = forwardRef<
 		const [schema, setSchema] = useState<any>(null)
 		const [loading, setLoading] = useState(false)
 		const [uiSchema, setUiSchema] = useState<any>(null)
+		const [existingDestination, setExistingDestination] = useState<
+			string | null
+		>(null)
 		const [filteredDestinations, setFilteredDestinations] = useState<
 			ExtendedDestination[]
 		>([])
@@ -397,6 +400,14 @@ const CreateDestination = forwardRef<
 		const handleConnectorChange = (value: string) => {
 			setFormData({})
 			setSchema(null)
+			setExistingDestination(null)
+
+			if (onDestinationNameChange) onDestinationNameChange("")
+			if (onVersionChange) onVersionChange("")
+
+			if (onFormDataChange) onFormDataChange({})
+			setDestinationName("")
+			setFormData({})
 			setConnector(value as ConnectorType)
 			if (onConnectorChange) {
 				onConnectorChange(value)
@@ -446,6 +457,7 @@ const CreateDestination = forwardRef<
 			if (onFormDataChange) onFormDataChange(configObj)
 			setDestinationName(selectedDestination.name)
 			setFormData(configObj)
+			setExistingDestination(value)
 		}
 
 		const handleVersionChange = (value: string) => {
@@ -543,7 +555,7 @@ const CreateDestination = forwardRef<
 								placeholder="Select a destination"
 								className="w-full"
 								onChange={handleExistingDestinationSelect}
-								value={undefined}
+								value={existingDestination}
 								options={filteredDestinations.map(d => ({
 									value: d.id,
 									label: d.name,

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -8,11 +8,11 @@ import {
 import { Link, useNavigate } from "react-router-dom"
 import { Input, message, Select, Spin } from "antd"
 import {
-	ArrowLeft,
-	ArrowRight,
-	ArrowSquareOut,
-	Info,
-	Notebook,
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	ArrowSquareOutIcon,
+	InfoIcon,
+	NotebookIcon,
 } from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 
@@ -405,20 +405,18 @@ const CreateDestination = forwardRef<
 		}
 
 		const handleConnectorChange = (value: string) => {
+			setConnector(value as ConnectorType)
+			if (setupType === SETUP_TYPES.EXISTING) {
+				setExistingDestination(null)
+			}
+			setVersion("")
 			setFormData({})
 			setSchema(null)
-			setExistingDestination(null)
 
-			if (onDestinationNameChange) onDestinationNameChange("")
-			if (onVersionChange) onVersionChange("")
-
-			if (onFormDataChange) onFormDataChange({})
-			setDestinationName("")
-			setFormData({})
-			setConnector(value as ConnectorType)
-			if (onConnectorChange) {
-				onConnectorChange(value)
-			}
+			// Parent callbacks
+			onConnectorChange?.(value)
+			onVersionChange?.("")
+			onFormDataChange?.({})
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {
@@ -436,6 +434,7 @@ const CreateDestination = forwardRef<
 				setFormData({})
 				setSchema(null)
 				setConnector(CONNECTOR_TYPES.DESTINATION_DEFAULT_CONNECTOR) // Reset to default connector
+				setExistingDestination(null)
 				// Schema will be automatically fetched due to useEffect when connector changes
 				if (onDestinationNameChange) onDestinationNameChange("")
 				if (onConnectorChange) onConnectorChange(CONNECTOR_TYPES.AMAZON_S3)
@@ -501,7 +500,7 @@ const CreateDestination = forwardRef<
 						<div className="w-1/2">
 							<FormField
 								label="OLake Version:"
-								tooltip="Choose the Olake version for the source"
+								tooltip="Choose the OLake version for the source"
 								info={
 									<a
 										href={OLAKE_LATEST_VERSION_URL}
@@ -509,7 +508,7 @@ const CreateDestination = forwardRef<
 										rel="noopener noreferrer"
 										className="flex items-center text-primary hover:text-primary/80"
 									>
-										<ArrowSquareOut className="size-4" />
+										<ArrowSquareOutIcon className="size-4" />
 									</a>
 								}
 							>
@@ -530,7 +529,7 @@ const CreateDestination = forwardRef<
 									/>
 								) : (
 									<div className="flex items-center gap-1 text-sm text-red-500">
-										<Info />
+										<InfoIcon />
 										No versions available
 									</div>
 								)}
@@ -647,7 +646,7 @@ const CreateDestination = forwardRef<
 								to={"/destinations"}
 								className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 							>
-								<ArrowLeft className="mr-1 size-5" />
+								<ArrowLeftIcon className="mr-1 size-5" />
 							</Link>
 							<div className="text-lg font-bold">Create destination</div>
 						</div>
@@ -665,7 +664,7 @@ const CreateDestination = forwardRef<
 								<div className="mb-6 mt-2 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
 									<div>
 										<div className="mb-4 flex items-center gap-2 text-base font-medium">
-											<Notebook className="size-5" />
+											<NotebookIcon className="size-5" />
 											Capture information
 										</div>
 
@@ -695,7 +694,7 @@ const CreateDestination = forwardRef<
 										}}
 									>
 										Create
-										<ArrowRight className="size-4 text-white" />
+										<ArrowRightIcon className="size-4 text-white" />
 									</button>
 								</div>
 							)}

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -7,7 +7,13 @@ import {
 } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { Input, message, Select, Spin } from "antd"
-import { ArrowLeft, ArrowRight, Info, Notebook } from "@phosphor-icons/react"
+import {
+	ArrowLeft,
+	ArrowRight,
+	ArrowSquareOut,
+	Info,
+	Notebook,
+} from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 
 import { useAppStore } from "../../../store"
@@ -27,6 +33,7 @@ import {
 import {
 	CONNECTOR_TYPES,
 	DESTINATION_INTERNAL_TYPES,
+	OLAKE_LATEST_VERSION_URL,
 	SETUP_TYPES,
 	transformErrors,
 } from "../../../utils/constants"
@@ -492,7 +499,20 @@ const CreateDestination = forwardRef<
 							</FormField>
 						</div>
 						<div className="w-1/2">
-							<FormField label="Version:">
+							<FormField
+								label="OLake Version:"
+								tooltip="Choose the Olake version for the source"
+								info={
+									<a
+										href={OLAKE_LATEST_VERSION_URL}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="flex items-center text-primary hover:text-primary/80"
+									>
+										<ArrowSquareOut className="size-4" />
+									</a>
+								}
+							>
 								{loadingVersions ? (
 									<div className="flex h-8 items-center justify-center">
 										<Spin size="small" />

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -503,7 +503,7 @@ const CreateDestination = forwardRef<
 						<div className="w-1/2">
 							<FormField
 								label="OLake Version:"
-								tooltip="Choose the OLake version for the source"
+								tooltip="Choose the OLake version for the destination"
 								info={
 									<a
 										href={OLAKE_LATEST_VERSION_URL}

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -408,17 +408,17 @@ const CreateDestination = forwardRef<
 			setConnector(value as ConnectorType)
 			if (setupType === SETUP_TYPES.EXISTING) {
 				setExistingDestination(null)
+				setDestinationName("")
+				onDestinationNameChange?.("")
 			}
 			setVersion("")
 			setFormData({})
 			setSchema(null)
-			setDestinationName("")
 
 			// Parent callbacks
 			onConnectorChange?.(value)
 			onVersionChange?.("")
 			onFormDataChange?.({})
-			onDestinationNameChange?.("")
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -1,9 +1,24 @@
 import React, { useState, useEffect, useRef } from "react"
 import { useParams, Link, useNavigate } from "react-router-dom"
 import { formatDistanceToNow } from "date-fns"
-import { Input, Button, Select, Switch, message, Spin, Table } from "antd"
+import {
+	Input,
+	Button,
+	Select,
+	Switch,
+	message,
+	Spin,
+	Table,
+	Tooltip,
+} from "antd"
 import type { ColumnsType } from "antd/es/table"
-import { ArrowLeft, Info, Notebook, PencilSimple } from "@phosphor-icons/react"
+import {
+	ArrowLeft,
+	ArrowSquareOut,
+	Info,
+	Notebook,
+	PencilSimple,
+} from "@phosphor-icons/react"
 import validator from "@rjsf/validator-ajv8"
 import Form from "@rjsf/antd"
 
@@ -31,6 +46,7 @@ import {
 	TAB_TYPES,
 	ENTITY_TYPES,
 	DISPLAYED_JOBS_COUNT,
+	OLAKE_LATEST_VERSION_URL,
 	transformErrors,
 } from "../../../utils/constants"
 import DocumentationPanel from "../../common/components/DocumentationPanel"
@@ -485,8 +501,22 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 							</div>
 						</div>
 						<div className="w-1/2">
-							<label className="mb-2 block text-sm font-medium text-gray-700">
-								Version:
+							<label className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
+								OLake Version:
+								<Tooltip title="Choose the OLake version for the source">
+									<Info
+										size={16}
+										className="cursor-help text-slate-900"
+									/>
+								</Tooltip>
+								<a
+									href={OLAKE_LATEST_VERSION_URL}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center text-primary hover:text-primary/80"
+								>
+									<ArrowSquareOut className="size-4" />
+								</a>
 							</label>
 							{loadingVersions ? (
 								<div className="flex h-8 items-center justify-center">

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -708,31 +708,30 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 								? renderConfigTab()
 								: renderJobsTab()}
 						</div>
-
 						{/* Footer */}
 						{!fromJobFlow && (
 							<div className="flex justify-between border-t border-gray-200 bg-white p-4 shadow-sm">
 								<div>
-									{
-										<button
-											className="ml-1 rounded-md border border-danger px-4 py-2 text-danger transition-colors duration-200 hover:bg-danger hover:text-white"
-											onClick={handleDelete}
-										>
-											Delete
-										</button>
-									}
+									<button
+										className="ml-1 rounded-md border border-danger px-4 py-2 text-danger transition-colors duration-200 hover:bg-danger hover:text-white"
+										onClick={handleDelete}
+									>
+										Delete
+									</button>
 								</div>
 								<div className="flex space-x-4">
-									<button
-										className="mr-1 flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white shadow-sm transition-colors duration-200 hover:bg-primary-600"
-										onClick={() => {
-											if (formRef.current) {
-												formRef.current.submit()
-											}
-										}}
-									>
-										Save Changes
-									</button>
+									{activeTab === TAB_TYPES.CONFIG && (
+										<button
+											className="mr-1 flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white shadow-sm transition-colors duration-200"
+											onClick={() => {
+												if (formRef.current) {
+													formRef.current.submit()
+												}
+											}}
+										>
+											Save changes
+										</button>
+									)}
 								</div>
 							</div>
 						)}

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -503,7 +503,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 						<div className="w-1/2">
 							<label className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
 								OLake Version:
-								<Tooltip title="Choose the OLake version for the source">
+								<Tooltip title="Choose the OLake version for the destination">
 									<Info
 										size={16}
 										className="cursor-help text-slate-900"

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -152,6 +152,8 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 						? JSON.parse(destination.config)
 						: destination.config
 				setFormData(config)
+			} else {
+				navigate("/destinations")
 			}
 		}
 	}, [destinationId, destinations, fetchDestinations])

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -480,7 +480,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 									onChange={updateConnector}
 									className="h-8 w-full"
 									options={connectorOptions}
-									disabled={fromJobFlow}
+									disabled
 								/>
 							</div>
 						</div>
@@ -524,7 +524,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 								value={destinationName}
 								onChange={e => updateDestinationName(e.target.value)}
 								className="h-8"
-								disabled={fromJobFlow}
+								disabled
 							/>
 						</div>
 					</div>

--- a/ui/src/modules/jobs/components/StepIndicator.tsx
+++ b/ui/src/modules/jobs/components/StepIndicator.tsx
@@ -7,6 +7,7 @@ const StepIndicator: React.FC<StepIndicatorProps> = ({
 	currentStep,
 	onStepClick,
 	isEditMode,
+	disabled,
 }) => {
 	const currentStepIndex = steps.indexOf(currentStep)
 	const isActive = currentStepIndex >= index
@@ -14,7 +15,7 @@ const StepIndicator: React.FC<StepIndicatorProps> = ({
 	const isLastStep = index === steps.length - 1
 
 	const handleClick = () => {
-		if (isEditMode && onStepClick) {
+		if (isEditMode && !disabled && onStepClick) {
 			onStepClick(step)
 		}
 	}
@@ -27,9 +28,9 @@ const StepIndicator: React.FC<StepIndicatorProps> = ({
 						isActive
 							? "border-primary outline outline-2 outline-primary"
 							: "border-gray-300 bg-white"
-					} ${isEditMode ? "cursor-pointer hover:bg-[#e8ebff]" : "cursor-not-allowed"}`}
+					} ${isEditMode && !disabled ? "cursor-pointer hover:bg-[#e8ebff]" : "cursor-not-allowed"}`}
 					onClick={handleClick}
-					disabled={!isEditMode}
+					disabled={!isEditMode || disabled}
 					type="button"
 				/>
 				{!isLastStep && (
@@ -44,9 +45,9 @@ const StepIndicator: React.FC<StepIndicatorProps> = ({
 			<button
 				className={`mt-2 inline translate-x-[-40%] text-xs ${
 					isActive ? "text-primary" : "text-[#6b7280]"
-				} ${isEditMode ? "cursor-pointer hover:text-primary" : "cursor-not-allowed"}`}
+				} ${isEditMode && !disabled ? "cursor-pointer hover:text-primary" : "cursor-not-allowed"}`}
 				onClick={handleClick}
-				disabled={!isEditMode}
+				disabled={!isEditMode || disabled}
 				type="button"
 			>
 				{step === "config"
@@ -61,6 +62,7 @@ const StepProgress: React.FC<StepProgressProps> = ({
 	currentStep,
 	onStepClick,
 	isEditMode,
+	disabled,
 }) => {
 	return (
 		<div className="flex items-center">
@@ -72,6 +74,7 @@ const StepProgress: React.FC<StepProgressProps> = ({
 					currentStep={currentStep}
 					onStepClick={onStepClick}
 					isEditMode={isEditMode}
+					disabled={disabled}
 				/>
 			))}
 		</div>

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -7,15 +7,15 @@ import { v4 as uuidv4 } from "uuid"
 import { useAppStore } from "../../../store"
 import { destinationService, sourceService, jobService } from "../../../api"
 
-import { JobBase, JobCreationSteps, SelectedStream } from "../../../types"
+import { JobBase, JobCreationSteps } from "../../../types"
 import {
 	getConnectorInLowerCase,
 	getSelectedStreams,
 	validateCronExpression,
+	validateStreams,
 } from "../../../utils/utils"
 import {
 	DESTINATION_INTERNAL_TYPES,
-	FILTER_REGEX,
 	JOB_CREATION_STEPS,
 	JOB_STEP_NUMBERS,
 } from "../../../utils/constants"
@@ -131,21 +131,6 @@ const JobCreation: React.FC = () => {
 		return validateCronExpression(cronExpression)
 	}
 
-	const validateFilter = (filter: string): boolean => {
-		if (!filter || !filter.trim()) return false
-		return FILTER_REGEX.test(filter.trim())
-	}
-
-	const validateStreams = (selections: {
-		[key: string]: SelectedStream[]
-	}): boolean => {
-		return !Object.values(selections).some(streams =>
-			streams.some(
-				sel => sel.filter !== undefined && !validateFilter(sel.filter),
-			),
-		)
-	}
-
 	const checkJobNameUnique = async (): Promise<boolean | null> => {
 		try {
 			const response = await jobService.checkJobNameUnique(jobName)
@@ -217,8 +202,8 @@ const JobCreation: React.FC = () => {
 				config: JSON.stringify(destinationFormData),
 			},
 			streams_config: JSON.stringify({
+				...selectedStreams,
 				selected_streams: getSelectedStreams(selectedStreams.selected_streams),
-				streams: selectedStreams.streams,
 			}),
 			frequency: cronExpression,
 		}

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -76,7 +76,9 @@ const JobCreation: React.FC = () => {
 	const [cronExpression, setCronExpression] = useState(
 		initialData.cronExpression || "* * * * *",
 	)
-	const [jobNameFilled, setJobNameFilled] = useState(false)
+	const [jobNameFilled, setJobNameFilled] = useState(
+		initialData.isJobNameFilled || false,
+	)
 	const [isStreamsLoading, setIsStreamsLoading] = useState(false)
 	const [isFromSources, setIsFromSources] = useState(true)
 

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -31,6 +31,7 @@ import TestConnectionSuccessModal from "../../common/Modals/TestConnectionSucces
 import TestConnectionFailureModal from "../../common/Modals/TestConnectionFailureModal"
 import EntitySavedModal from "../../common/Modals/EntitySavedModal"
 import EntityCancelModal from "../../common/Modals/EntityCancelModal"
+import ResetStreamsModal from "../../common/Modals/ResetStreamsModal"
 
 const JobCreation: React.FC = () => {
 	const navigate = useNavigate()
@@ -87,6 +88,7 @@ const JobCreation: React.FC = () => {
 		setShowFailureModal,
 		setSourceTestConnectionError,
 		setDestinationTestConnectionError,
+		setShowResetStreamsModal,
 	} = useAppStore()
 
 	const sourceRef = useRef<any>(null)
@@ -309,6 +311,11 @@ const JobCreation: React.FC = () => {
 
 	//TODO: Handle steps properly
 
+	const handleConfirmResetStreams = () => {
+		setSelectedStreams([])
+		setCurrentStep(JOB_CREATION_STEPS.DESTINATION)
+	}
+
 	const nextStep = () => {
 		if (currentStep === JOB_CREATION_STEPS.SOURCE) {
 			setCurrentStep(JOB_CREATION_STEPS.DESTINATION)
@@ -323,7 +330,7 @@ const JobCreation: React.FC = () => {
 		if (currentStep === JOB_CREATION_STEPS.DESTINATION) {
 			setCurrentStep(JOB_CREATION_STEPS.SOURCE)
 		} else if (currentStep === JOB_CREATION_STEPS.STREAMS) {
-			setCurrentStep(JOB_CREATION_STEPS.DESTINATION)
+			setShowResetStreamsModal(true)
 		} else if (currentStep === JOB_CREATION_STEPS.SOURCE) {
 			setCurrentStep(JOB_CREATION_STEPS.CONFIG)
 		}
@@ -558,6 +565,7 @@ const JobCreation: React.FC = () => {
 					/>
 				</div>
 			</div>
+			<ResetStreamsModal onConfirm={handleConfirmResetStreams} />
 		</div>
 	)
 }

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -10,6 +10,7 @@ import { destinationService, sourceService } from "../../../api"
 import { JobBase, JobCreationSteps } from "../../../types"
 import {
 	getConnectorInLowerCase,
+	getSelectedStreams,
 	validateCronExpression,
 } from "../../../utils/utils"
 import { DESTINATION_INTERNAL_TYPES } from "../../../utils/constants"
@@ -180,7 +181,10 @@ const JobCreation: React.FC = () => {
 				version: destinationVersion,
 				config: JSON.stringify(destinationFormData),
 			},
-			streams_config: JSON.stringify(selectedStreams),
+			streams_config: JSON.stringify({
+				selected_streams: getSelectedStreams(selectedStreams.selected_streams),
+				streams: selectedStreams.streams,
+			}),
 			frequency: cronExpression,
 		}
 

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -77,6 +77,7 @@ const JobCreation: React.FC = () => {
 		initialData.cronExpression || "* * * * *",
 	)
 	const [jobNameFilled, setJobNameFilled] = useState(false)
+	const [isStreamsLoading, setIsStreamsLoading] = useState(false)
 	const [isFromSources, setIsFromSources] = useState(true)
 
 	const {
@@ -474,6 +475,7 @@ const JobCreation: React.FC = () => {
 								}
 								destinationType={getConnectorInLowerCase(destinationConnector)}
 								jobName={jobName}
+								onLoadingChange={setIsStreamsLoading}
 							/>
 						</div>
 					)}
@@ -515,7 +517,10 @@ const JobCreation: React.FC = () => {
 					{currentStep !== JOB_CREATION_STEPS.CONFIG && (
 						<button
 							onClick={handleBack}
-							className="mr-4 rounded-md border border-gray-400 px-4 py-1 font-light hover:bg-[#ebebeb]"
+							className="mr-4 rounded-md border border-gray-400 px-4 py-1 font-light hover:bg-[#ebebeb] disabled:cursor-not-allowed disabled:opacity-50"
+							disabled={
+								currentStep === JOB_CREATION_STEPS.STREAMS && isStreamsLoading
+							}
 						>
 							Back
 						</button>

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -460,6 +460,7 @@ const JobEdit: React.FC = () => {
 						currentStep={currentStep}
 						onStepClick={handleStepClick}
 						isEditMode={!!jobId}
+						disabled={isStreamsLoading}
 					/>
 				</div>
 			</div>

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -34,6 +34,7 @@ import {
 	JOB_CREATION_STEPS,
 	JOB_STEP_NUMBERS,
 } from "../../../utils/constants"
+import ResetStreamsModal from "../../common/Modals/ResetStreamsModal"
 
 // Custom wrapper component for SourceEdit to use in job flow
 const JobSourceEdit = ({
@@ -125,7 +126,13 @@ const JobDestinationEdit = ({
 const JobEdit: React.FC = () => {
 	const navigate = useNavigate()
 	const { jobId } = useParams<{ jobId: string }>()
-	const { jobs, fetchJobs, fetchSources, fetchDestinations } = useAppStore()
+	const {
+		jobs,
+		fetchJobs,
+		fetchSources,
+		fetchDestinations,
+		setShowResetStreamsModal,
+	} = useAppStore()
 
 	const [currentStep, setCurrentStep] = useState<JobCreationSteps>(
 		JOB_CREATION_STEPS.STREAMS,
@@ -136,6 +143,7 @@ const JobEdit: React.FC = () => {
 	const [sourceData, setSourceData] = useState<SourceData | null>(null)
 	const [destinationData, setDestinationData] =
 		useState<DestinationData | null>(null)
+	const [nextStep, setNextStep] = useState<JobCreationSteps | null>(null)
 
 	// Streams step states
 	const [selectedStreams, setSelectedStreams] = useState<StreamsDataStructure>({
@@ -149,6 +157,7 @@ const JobEdit: React.FC = () => {
 	const [job, setJob] = useState<Job | null>(null)
 	const [isFromSources, setIsFromSources] = useState(true)
 	const [streamsModified, setStreamsModified] = useState(false)
+	const [isStreamsLoading, setIsStreamsLoading] = useState(false)
 
 	// Load job data on component mount
 	useEffect(() => {
@@ -397,13 +406,18 @@ const JobEdit: React.FC = () => {
 		if (currentStep === JOB_CREATION_STEPS.DESTINATION) {
 			setCurrentStep(JOB_CREATION_STEPS.SOURCE)
 		} else if (currentStep === JOB_CREATION_STEPS.STREAMS) {
-			setCurrentStep(JOB_CREATION_STEPS.DESTINATION)
+			setShowResetStreamsModal(true)
 		} else if (currentStep === JOB_CREATION_STEPS.SOURCE) {
 			setCurrentStep(JOB_CREATION_STEPS.CONFIG)
 		}
 	}
 
 	const handleStepClick = async (step: string) => {
+		if (currentStep === JOB_CREATION_STEPS.STREAMS) {
+			setNextStep(step as JobCreationSteps)
+			setShowResetStreamsModal(true)
+			return
+		}
 		setCurrentStep(step as JobCreationSteps)
 	}
 
@@ -411,6 +425,19 @@ const JobEdit: React.FC = () => {
 		setSelectedStreams(newStreams)
 		setStreamsModified(true)
 	}
+
+	const handleConfirmResetStreams = () => {
+		setSelectedStreams({
+			selected_streams: {},
+			streams: [],
+		})
+		setNextStep(null)
+		setCurrentStep(nextStep || JOB_CREATION_STEPS.DESTINATION)
+	}
+
+	const isBackDisabled =
+		currentStep === JOB_CREATION_STEPS.CONFIG ||
+		(currentStep === JOB_CREATION_STEPS.STREAMS && isStreamsLoading)
 
 	return (
 		<div className="flex h-screen flex-col">
@@ -485,6 +512,7 @@ const JobEdit: React.FC = () => {
 										streamsModified ? selectedStreams : undefined
 									}
 									jobName={jobName}
+									onLoadingChange={setIsStreamsLoading}
 								/>
 							</div>
 						)}
@@ -509,13 +537,10 @@ const JobEdit: React.FC = () => {
 					<button
 						className="rounded-md border border-gray-400 px-4 py-1 font-light hover:bg-[#ebebeb]"
 						onClick={handleBack}
-						disabled={currentStep === JOB_CREATION_STEPS.CONFIG}
+						disabled={isBackDisabled}
 						style={{
-							opacity: currentStep === JOB_CREATION_STEPS.CONFIG ? 0.5 : 1,
-							cursor:
-								currentStep === JOB_CREATION_STEPS.CONFIG
-									? "not-allowed"
-									: "pointer",
+							opacity: isBackDisabled ? 0.5 : 1,
+							cursor: isBackDisabled ? "not-allowed" : "pointer",
 						}}
 					>
 						Back
@@ -559,6 +584,7 @@ const JobEdit: React.FC = () => {
 			<TestConnectionModal />
 			<TestConnectionSuccessModal />
 			<TestConnectionFailureModal fromSources={isFromSources} />
+			<ResetStreamsModal onConfirm={handleConfirmResetStreams} />
 		</div>
 	)
 }

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -25,6 +25,7 @@ import TestConnectionSuccessModal from "../../common/Modals/TestConnectionSucces
 import TestConnectionFailureModal from "../../common/Modals/TestConnectionFailureModal"
 import {
 	getConnectorInLowerCase,
+	getSelectedStreams,
 	validateCronExpression,
 } from "../../../utils/utils"
 import { DESTINATION_INTERNAL_TYPES } from "../../../utils/constants"
@@ -312,7 +313,12 @@ const JobEdit: React.FC = () => {
 			streams_config:
 				typeof selectedStreams === "string"
 					? selectedStreams
-					: JSON.stringify(selectedStreams),
+					: JSON.stringify({
+							selectedStreams: getSelectedStreams(
+								selectedStreams.selected_streams,
+							),
+							streams: selectedStreams.streams,
+						}),
 			frequency: cronExpression,
 			activate: job?.activate,
 		}

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -322,10 +322,10 @@ const JobEdit: React.FC = () => {
 				typeof selectedStreams === "string"
 					? selectedStreams
 					: JSON.stringify({
-							selectedStreams: getSelectedStreams(
+							...selectedStreams,
+							selected_streams: getSelectedStreams(
 								selectedStreams.selected_streams,
 							),
-							streams: selectedStreams.streams,
 						}),
 			frequency: cronExpression,
 			activate: job?.activate,

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -27,6 +27,7 @@ import {
 	getConnectorInLowerCase,
 	getSelectedStreams,
 	validateCronExpression,
+	validateStreams,
 } from "../../../utils/utils"
 import {
 	DESTINATION_INTERNAL_TYPES,
@@ -337,6 +338,13 @@ const JobEdit: React.FC = () => {
 	const handleJobSubmit = async () => {
 		if (!sourceData || !destinationData || !jobId) {
 			message.error("Source and destination data are required")
+			return
+		}
+
+		if (
+			!validateStreams(getSelectedStreams(selectedStreams.selected_streams))
+		) {
+			message.error("Filter Value cannot be empty")
 			return
 		}
 

--- a/ui/src/modules/jobs/pages/JobLogs.tsx
+++ b/ui/src/modules/jobs/pages/JobLogs.tsx
@@ -171,9 +171,11 @@ const JobLogs: React.FC = () => {
 								if (isTaskLog && filePath) {
 									fetchTaskLogs(jobId!, historyId || "1", filePath)
 										.then(() => {
+											message.destroy()
 											message.success("Logs refetched successfully")
 										})
 										.catch(error => {
+											message.destroy()
 											message.error("Failed to refetch task logs")
 											console.error(error)
 										})

--- a/ui/src/modules/jobs/pages/Jobs.tsx
+++ b/ui/src/modules/jobs/pages/Jobs.tsx
@@ -66,6 +66,7 @@ const Jobs: React.FC = () => {
 					selectedStreams: JSON.parse(savedJob.streams_config),
 					jobName: savedJob.name,
 					cronExpression: savedJob.frequency,
+					isJobNameFilled: true,
 				}
 				navigate("/jobs/new", {
 					state: {

--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -337,12 +337,10 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 			const existingStream = updated.selected_streams[namespace]?.find(
 				s => s.stream_name === streamName,
 			)
-
 			if (checked) {
 				if (!updated.selected_streams[namespace]) {
 					updated.selected_streams[namespace] = []
 				}
-
 				if (!existingStream) {
 					updated.selected_streams[namespace] = [
 						...updated.selected_streams[namespace],
@@ -373,10 +371,8 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 					changed = true
 				}
 			}
-
 			return changed ? updated : prev
 		})
-
 		setTimeout(() => {
 			setApiResponse(current => {
 				if (!current) return current

--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -446,9 +446,11 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 
 		return tempFilteredStreams.filter(stream => {
 			const ns = stream.stream.namespace || ""
-			const isSelected = apiResponse.selected_streams[ns]?.some(
+			const matchingSelectedStream = apiResponse.selected_streams[ns]?.find(
 				s => s.stream_name === stream.stream.name,
 			)
+			const isSelected =
+				matchingSelectedStream && !matchingSelectedStream.disabled
 			if (showSelected && showNotSelected) return true
 			if (showSelected) return isSelected
 			if (showNotSelected) return !isSelected

--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -38,6 +38,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 	jobId = -1,
 	destinationType,
 	jobName,
+	onLoadingChange,
 }) => {
 	const prevSourceConfig = useRef(sourceConfig)
 	const { setShowDestinationDatabaseModal } = useAppStore()
@@ -119,6 +120,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 			setApiResponse(initialStreamsData)
 			setSelectedStreams(initialStreamsData)
 			setLoading(false)
+			onLoadingChange?.(false)
 			initialized.current = true
 
 			// Select first stream if no stream is currently active
@@ -131,6 +133,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 		const fetchSourceStreams = async () => {
 			if (initialized.current) return
 
+			onLoadingChange?.(true)
 			setLoading(true)
 			try {
 				const response = await sourceService.getSourceStreams(
@@ -193,6 +196,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 				console.error("Error fetching source streams:", error)
 			} finally {
 				setLoading(false)
+				onLoadingChange?.(false)
 			}
 		}
 

--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -406,9 +406,19 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 
 			const updatedSelectedStreams = {
 				...prev.selected_streams,
-				[namespace]: prev.selected_streams[namespace].map(s =>
-					s.stream_name === streamName ? { ...s, filter: filterValue } : s,
-				),
+				[namespace]: prev.selected_streams[namespace].map(s => {
+					if (s.stream_name === streamName) {
+						if (filterValue === "") {
+							// Remove the 'filter' if filterValue is empty
+							const updatedStream = { ...s }
+							delete updatedStream.filter
+							return updatedStream
+						} else {
+							return { ...s, filter: filterValue }
+						}
+					}
+					return s
+				}),
 			}
 
 			const updated = {

--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -454,7 +454,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 				s => s.stream_name === stream.stream.name,
 			)
 			const isSelected =
-				matchingSelectedStream && !matchingSelectedStream.disabled
+				matchingSelectedStream && !matchingSelectedStream?.disabled
 			if (showSelected && showNotSelected) return true
 			if (showSelected) return isSelected
 			if (showNotSelected) return !isSelected

--- a/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
@@ -409,7 +409,7 @@ const StreamConfiguration = ({
 			!firstCondition.operator ||
 			!firstCondition.value
 		) {
-			message.error("Please complete the first filter before adding another.")
+			message.error("Please complete the first filter before applying another.")
 			return
 		}
 

--- a/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
@@ -299,42 +299,23 @@ const StreamConfiguration = ({
 			[streamKey]: checked,
 		}))
 
-		if (!checked) {
-			setMultiFilterCondition({
-				conditions: [
-					{
-						columnName: "",
-						operator: "=",
-						value: "",
-					},
-				],
-				logicalOperator: "and",
-			})
-			isLocalFilterUpdateRef.current = true
-			onFullLoadFilterChange?.(
-				stream.stream.name,
-				stream.stream.namespace || "",
-				"",
-			)
-		} else {
-			// if toggled on insert empty condition
-			setMultiFilterCondition({
-				conditions: [
-					{
-						columnName: "",
-						operator: "=",
-						value: "",
-					},
-				],
-				logicalOperator: "and",
-			})
-			isLocalFilterUpdateRef.current = true
-			onFullLoadFilterChange?.(
-				stream.stream.name,
-				stream.stream.namespace || "",
-				"=",
-			)
-		}
+		setMultiFilterCondition({
+			conditions: [
+				{
+					columnName: "",
+					operator: "=",
+					value: "",
+				},
+			],
+			logicalOperator: "and",
+		})
+		isLocalFilterUpdateRef.current = true
+		// If toggled on insert empty condition
+		onFullLoadFilterChange?.(
+			stream.stream.name,
+			stream.stream.namespace || "",
+			checked ? "=" : "",
+		)
 	}
 
 	const handleFilterConditionChange = (
@@ -359,7 +340,7 @@ const StreamConfiguration = ({
 				cond =>
 					`${cond.columnName} ${cond.operator} ${formatFilterValue(cond.columnName, cond.value)}`,
 			)
-			.join(` ${multiFilterCondition.logicalOperator} `)
+			.join(` ${newMultiCondition.logicalOperator} `)
 
 		isLocalFilterUpdateRef.current = true
 		onFullLoadFilterChange?.(

--- a/ui/src/modules/jobs/pages/streams/StreamsCollapsibleList.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamsCollapsibleList.tsx
@@ -65,18 +65,20 @@ const StreamsCollapsibleList = ({
 
 				if ("selected_streams" in selectedStreams) {
 					// CombinedStreamsData format
-					isStreamSelected = !!(selectedStreams as any).selected_streams[
+					const selectedStream = (selectedStreams as any).selected_streams[
 						ns
-					]?.some(
-						(selected: { stream_name: string }) =>
+					]?.find(
+						(selected: { stream_name: string; disabled?: boolean }) =>
 							selected.stream_name === streamName,
 					)
+					isStreamSelected = !!(selectedStream && !selectedStream.disabled)
 				} else {
 					// Regular mapping format
-					isStreamSelected = !!(selectedStreams as any)[ns]?.some(
-						(selected: { stream_name: string }) =>
+					const selectedStream = (selectedStreams as any)[ns]?.find(
+						(selected: { stream_name: string; disabled?: boolean }) =>
 							selected.stream_name === streamName,
 					)
+					isStreamSelected = !!(selectedStream && !selectedStream.disabled)
 				}
 
 				newCheckedStatus.streams[ns][streamName] = isStreamSelected

--- a/ui/src/modules/jobs/pages/streams/StreamsCollapsibleList.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamsCollapsibleList.tsx
@@ -11,7 +11,6 @@ const StreamsCollapsibleList = ({
 	setActiveStreamData,
 	activeStreamData,
 	onStreamSelect,
-	setSelectedStreams,
 }: GroupedStreamsCollapsibleListProps) => {
 	const [openNamespaces, setOpenNamespaces] = useState<{
 		[ns: string]: boolean
@@ -137,72 +136,12 @@ const StreamsCollapsibleList = ({
 			streamsInNamespace.forEach(streamData => {
 				onStreamSelect(streamData.stream.name, false, ns)
 			})
-
-			// Then manually call setSelectedStreams as a fallback approach
-			setTimeout(() => {
-				if (
-					typeof selectedStreams === "object" &&
-					selectedStreams !== null &&
-					"selected_streams" in selectedStreams &&
-					selectedStreams.selected_streams // Ensure selected_streams itself is not null/undefined
-				) {
-					// selectedStreams is of type { selected_streams: { [key: string]: StreamDetail[] }, streams: StreamData[] }
-					const updatedState = {
-						...selectedStreams,
-						selected_streams: {
-							...selectedStreams.selected_streams,
-							[ns]: [],
-						},
-					}
-					setSelectedStreams(updatedState)
-				}
-			}, 100)
 		} else {
 			const streamsInNamespace = groupedStreams[ns] || []
 
 			streamsInNamespace.forEach(streamData => {
 				onStreamSelect(streamData.stream.name, true, ns)
 			})
-
-			setTimeout(() => {
-				const streamNames = streamsInNamespace.map(s => s.stream.name)
-				const newStreamEntries = streamNames.map(stream_name => ({
-					stream_name,
-					partition_regex: "",
-					normalization: false,
-				}))
-
-				if (selectedStreams) {
-					if (
-						typeof selectedStreams === "object" &&
-						selectedStreams !== null &&
-						"selected_streams" in selectedStreams &&
-						selectedStreams.selected_streams
-					) {
-						// selectedStreams is of type { selected_streams: { [key: string]: StreamDetail[] }, streams: StreamData[] }
-						const updatedState = {
-							...selectedStreams,
-							selected_streams: {
-								...selectedStreams.selected_streams,
-								[ns]: newStreamEntries,
-							},
-						}
-						setSelectedStreams(updatedState)
-					} else if (
-						typeof selectedStreams === "object" &&
-						selectedStreams !== null &&
-						!Array.isArray(selectedStreams) &&
-						!("selected_streams" in selectedStreams)
-					) {
-						// selectedStreams is of type { [key: string]: StreamDetail[] }
-						const updatedState = {
-							...(selectedStreams as { [key: string]: any }), // Cast to allow spread for generic object map
-							[ns]: newStreamEntries,
-						}
-						setSelectedStreams(updatedState)
-					}
-				}
-			}, 100)
 		}
 	}
 

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -75,6 +75,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 		const [loading, setLoading] = useState(false)
 		const [filteredSources, setFilteredSources] = useState<Source[]>([])
 		const [sourceNameError, setSourceNameError] = useState<string | null>(null)
+		const [existingSource, setExistingSource] = useState<string | null>(null)
 
 		const navigate = useNavigate()
 
@@ -311,9 +312,21 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 			setFormData({})
 			setSchema(null)
 			setConnector(value)
+			setExistingSource(null)
 			if (onConnectorChange) {
 				onConnectorChange(value)
 			}
+			if (onSourceNameChange) {
+				onSourceNameChange("")
+			}
+			if (onVersionChange) {
+				onVersionChange("")
+			}
+			if (onFormDataChange) {
+				onFormDataChange("")
+			}
+			setSourceName("")
+			setSelectedVersion("")
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {
@@ -357,6 +370,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 				if (onFormDataChange) {
 					onFormDataChange(selectedSource.config)
 				}
+				setExistingSource(value)
 				setSourceName(selectedSource.name)
 				setConnector(getConnectorLabel(selectedSource.type))
 				setSelectedVersion(selectedSource.version)
@@ -460,7 +474,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 						placeholder="Select a source"
 						className="w-full"
 						onChange={handleExistingSourceSelect}
-						value={undefined}
+						value={existingSource}
 						options={filteredSources.map(s => ({
 							value: s.id,
 							label: s.name,

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -348,7 +348,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 				}
 			}
 			// Clear form data when switching to new source
-			if (type === "new") {
+			if (type === SETUP_TYPES.NEW) {
 				setFormData({})
 				setSchema(null)
 				setConnector(CONNECTOR_TYPES.SOURCE_DEFAULT_CONNECTOR) // Reset to default connector

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -326,11 +326,13 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 			setSelectedVersion("")
 			setFormData({})
 			setSchema(null)
+			setSourceName("")
 
 			// Parent callbacks
 			onConnectorChange?.(value)
 			onVersionChange?.("")
 			onFormDataChange?.({})
+			onSourceNameChange?.("")
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -337,6 +337,9 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 
 		const handleSetupTypeChange = (type: SetupType) => {
 			setSetupType(type)
+			setSourceName("")
+			onSourceNameChange?.("")
+
 			if (onDocsMinimizedChange) {
 				if (type === SETUP_TYPES.EXISTING) {
 					onDocsMinimizedChange(true) // Close doc panel
@@ -346,13 +349,11 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 			}
 			// Clear form data when switching to new source
 			if (type === "new") {
-				setSourceName("")
 				setFormData({})
 				setSchema(null)
 				setConnector(CONNECTOR_TYPES.SOURCE_DEFAULT_CONNECTOR) // Reset to default connector
 				setExistingSource(null)
 				// Schema will be automatically fetched due to useEffect when connector changes
-				if (onSourceNameChange) onSourceNameChange("")
 				if (onConnectorChange) onConnectorChange(CONNECTOR_TYPES.MONGODB)
 				if (onFormDataChange) onFormDataChange({})
 				if (onVersionChange) onVersionChange("")

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -322,17 +322,17 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 			setConnector(value)
 			if (setupType === SETUP_TYPES.EXISTING) {
 				setExistingSource(null)
+				setSourceName("")
+				onSourceNameChange?.("")
 			}
 			setSelectedVersion("")
 			setFormData({})
 			setSchema(null)
-			setSourceName("")
 
 			// Parent callbacks
 			onConnectorChange?.(value)
 			onVersionChange?.("")
 			onFormDataChange?.({})
-			onSourceNameChange?.("")
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -8,11 +8,11 @@ import {
 import { Link, useNavigate } from "react-router-dom"
 import { message, Select, Spin, Tooltip } from "antd"
 import {
-	ArrowLeft,
-	ArrowRight,
-	ArrowSquareOut,
-	Info,
-	Notebook,
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	ArrowSquareOutIcon,
+	InfoIcon,
+	NotebookIcon,
 } from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 import validator from "@rjsf/validator-ajv8"
@@ -319,24 +319,18 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 		}
 
 		const handleConnectorChange = (value: string) => {
+			setConnector(value)
+			if (setupType === SETUP_TYPES.EXISTING) {
+				setExistingSource(null)
+			}
+			setSelectedVersion("")
 			setFormData({})
 			setSchema(null)
-			setConnector(value)
-			setExistingSource(null)
-			if (onConnectorChange) {
-				onConnectorChange(value)
-			}
-			if (onSourceNameChange) {
-				onSourceNameChange("")
-			}
-			if (onVersionChange) {
-				onVersionChange("")
-			}
-			if (onFormDataChange) {
-				onFormDataChange("")
-			}
-			setSourceName("")
-			setSelectedVersion("")
+
+			// Parent callbacks
+			onConnectorChange?.(value)
+			onVersionChange?.("")
+			onFormDataChange?.({})
 		}
 
 		const handleSetupTypeChange = (type: SetupType) => {
@@ -354,6 +348,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 				setFormData({})
 				setSchema(null)
 				setConnector(CONNECTOR_TYPES.SOURCE_DEFAULT_CONNECTOR) // Reset to default connector
+				setExistingSource(null)
 				// Schema will be automatically fetched due to useEffect when connector changes
 				if (onSourceNameChange) onSourceNameChange("")
 				if (onConnectorChange) onConnectorChange(CONNECTOR_TYPES.MONGODB)
@@ -428,7 +423,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 						<label className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
 							OLake Version:
 							<Tooltip title="Choose the OLake version for the source">
-								<Info
+								<InfoIcon
 									size={16}
 									className="cursor-help text-slate-900"
 								/>
@@ -439,7 +434,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 								rel="noopener noreferrer"
 								className="flex items-center text-primary hover:text-primary/80"
 							>
-								<ArrowSquareOut className="size-4" />
+								<ArrowSquareOutIcon className="size-4" />
 							</a>
 						</label>
 						{loadingVersions ? (
@@ -461,7 +456,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 							</>
 						) : (
 							<div className="flex items-center gap-1 text-sm text-red-500">
-								<Info />
+								<InfoIcon />
 								No versions available
 							</div>
 						)}
@@ -569,7 +564,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 								to={"/sources"}
 								className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 							>
-								<ArrowLeft className="mr-1 size-5" />
+								<ArrowLeftIcon className="mr-1 size-5" />
 							</Link>
 							<div className="text-lg font-bold">Create source</div>
 						</div>
@@ -587,7 +582,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 								<div className="mb-6 mt-2 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
 									<div className="mb-6">
 										<div className="mb-4 flex items-center gap-2 text-base font-medium">
-											<Notebook className="size-5" />
+											<NotebookIcon className="size-5" />
 											Capture information
 										</div>
 
@@ -620,7 +615,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 										}}
 									>
 										Create
-										<ArrowRight className="size-4 text-white" />
+										<ArrowRightIcon className="size-4 text-white" />
 									</button>
 								</div>
 							)}

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -6,8 +6,14 @@ import {
 	useRef,
 } from "react"
 import { Link, useNavigate } from "react-router-dom"
-import { message, Select, Spin } from "antd"
-import { ArrowLeft, ArrowRight, Info, Notebook } from "@phosphor-icons/react"
+import { message, Select, Spin, Tooltip } from "antd"
+import {
+	ArrowLeft,
+	ArrowRight,
+	ArrowSquareOut,
+	Info,
+	Notebook,
+} from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 import validator from "@rjsf/validator-ajv8"
 
@@ -19,7 +25,11 @@ import {
 	handleSpecResponse,
 	withAbortController,
 } from "../../../utils/utils"
-import { CONNECTOR_TYPES, transformErrors } from "../../../utils/constants"
+import {
+	CONNECTOR_TYPES,
+	OLAKE_LATEST_VERSION_URL,
+	transformErrors,
+} from "../../../utils/constants"
 import EndpointTitle from "../../../utils/EndpointTitle"
 import FormField from "../../../utils/FormField"
 import DocumentationPanel from "../../common/components/DocumentationPanel"
@@ -415,8 +425,22 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 					{renderConnectorSelection()}
 
 					<div className="w-1/2">
-						<label className="mb-2 block text-sm font-medium text-gray-700">
+						<label className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
 							OLake Version:
+							<Tooltip title="Choose the OLake version for the source">
+								<Info
+									size={16}
+									className="cursor-help text-slate-900"
+								/>
+							</Tooltip>
+							<a
+								href={OLAKE_LATEST_VERSION_URL}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="flex items-center text-primary hover:text-primary/80"
+							>
+								<ArrowSquareOut className="size-4" />
+							</a>
 						</label>
 						{loadingVersions ? (
 							<div className="flex h-8 items-center justify-center">

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -526,7 +526,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 														}}
 														className="h-8 w-full"
 														options={connectorOptions}
-														disabled={fromJobFlow}
+														disabled
 													/>
 												</div>
 											</div>
@@ -546,7 +546,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 														}
 													}}
 													className="h-8"
-													disabled={fromJobFlow}
+													disabled
 												/>
 											</div>
 

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -1,7 +1,16 @@
 import { useState, useEffect, useRef } from "react"
 import { useParams, useNavigate, Link } from "react-router-dom"
 import { formatDistanceToNow } from "date-fns"
-import { Input, Button, Select, Switch, message, Table, Spin } from "antd"
+import {
+	Input,
+	Button,
+	Select,
+	Switch,
+	message,
+	Table,
+	Spin,
+	Tooltip,
+} from "antd"
 import type { ColumnsType } from "antd/es/table"
 import {
 	GenderNeuter,
@@ -9,6 +18,7 @@ import {
 	ArrowLeft,
 	PencilSimple,
 	Info,
+	ArrowSquareOut,
 } from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 import validator from "@rjsf/validator-ajv8"
@@ -36,6 +46,7 @@ import { getStatusIcon } from "../../../utils/statusIcons"
 import {
 	connectorTypeMap,
 	DISPLAYED_JOBS_COUNT,
+	OLAKE_LATEST_VERSION_URL,
 	transformErrors,
 } from "../../../utils/constants"
 import ObjectFieldTemplate from "../../common/components/Form/ObjectFieldTemplate"
@@ -551,9 +562,23 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 											</div>
 
 											<div>
-												<label className="mb-2 block text-sm font-medium text-gray-700">
+												<label className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
 													OLake Version:
 													<span className="text-red-500">*</span>
+													<Tooltip title="Choose the OLake version for the source">
+														<Info
+															size={16}
+															className="cursor-help text-slate-900"
+														/>
+													</Tooltip>
+													<a
+														href={OLAKE_LATEST_VERSION_URL}
+														target="_blank"
+														rel="noopener noreferrer"
+														className="flex items-center text-primary hover:text-primary/80"
+													>
+														<ArrowSquareOut className="size-4" />
+													</a>
 												</label>
 												{loadingVersions ? (
 													<div className="flex h-8 items-center justify-center">

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -685,16 +685,18 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 									</button>
 								</div>
 								<div className="flex space-x-4">
-									<button
-										className="mr-1 flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white shadow-sm transition-colors duration-200 hover:bg-primary-600"
-										onClick={() => {
-											if (formRef.current) {
-												formRef.current.submit()
-											}
-										}}
-									>
-										Save changes
-									</button>
+									{activeTab === "config" && (
+										<button
+											className="mr-1 flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white shadow-sm transition-colors duration-200"
+											onClick={() => {
+												if (formRef.current) {
+													formRef.current.submit()
+												}
+											}}
+										>
+											Save changes
+										</button>
+									)}
 								</div>
 							</div>
 						)}

--- a/ui/src/store/modalStore.ts
+++ b/ui/src/store/modalStore.ts
@@ -13,6 +13,7 @@ export interface ModalSlice {
 	showEditSourceModal: boolean
 	showEditDestinationModal: boolean
 	showDestinationDatabaseModal: boolean
+	showResetStreamsModal: boolean
 	setShowTestingModal: (show: boolean) => void
 	setShowSuccessModal: (show: boolean) => void
 	setShowFailureModal: (show: boolean) => void
@@ -25,6 +26,7 @@ export interface ModalSlice {
 	setShowEditSourceModal: (show: boolean) => void
 	setShowEditDestinationModal: (show: boolean) => void
 	setShowDestinationDatabaseModal: (show: boolean) => void
+	setShowResetStreamsModal: (show: boolean) => void
 }
 
 export const createModalSlice: StateCreator<ModalSlice> = set => ({
@@ -40,6 +42,7 @@ export const createModalSlice: StateCreator<ModalSlice> = set => ({
 	showEditSourceModal: false,
 	showEditDestinationModal: false,
 	showDestinationDatabaseModal: false,
+	showResetStreamsModal: false,
 
 	setShowTestingModal: show => set({ showTestingModal: show }),
 	setShowSuccessModal: show => set({ showSuccessModal: show }),
@@ -55,4 +58,5 @@ export const createModalSlice: StateCreator<ModalSlice> = set => ({
 	setShowEditDestinationModal: show => set({ showEditDestinationModal: show }),
 	setShowDestinationDatabaseModal: show =>
 		set({ showDestinationDatabaseModal: show }),
+	setShowResetStreamsModal: show => set({ showResetStreamsModal: show }),
 })

--- a/ui/src/types/commonTypes.ts
+++ b/ui/src/types/commonTypes.ts
@@ -53,12 +53,14 @@ export interface StepIndicatorProps {
 	currentStep: string
 	onStepClick?: (step: string) => void
 	isEditMode?: boolean
+	disabled?: boolean
 }
 
 export interface StepProgressProps {
 	currentStep: string
 	onStepClick?: (step: string) => void
 	isEditMode?: boolean
+	disabled?: boolean
 }
 
 export interface CatalogOption {

--- a/ui/src/types/formTypes.ts
+++ b/ui/src/types/formTypes.ts
@@ -4,6 +4,8 @@ export interface FormFieldProps {
 	required?: boolean
 	children: React.ReactNode
 	error?: string | null
+	tooltip?: React.ReactNode
+	info?: React.ReactNode
 }
 
 export interface DynamicSchemaFormProps {

--- a/ui/src/types/modalTypes.ts
+++ b/ui/src/types/modalTypes.ts
@@ -12,3 +12,7 @@ export interface DestinationDatabaseModalProps {
 	originalDatabase: string
 	initialStreams: StreamsDataStructure | null
 }
+
+export interface ResetStreamsModalProps {
+	onConfirm: () => void
+}

--- a/ui/src/types/streamTypes.ts
+++ b/ui/src/types/streamTypes.ts
@@ -84,6 +84,7 @@ export interface SelectedStream {
 	partition_regex: string
 	normalization: boolean
 	filter?: string
+	disabled?: boolean
 }
 
 export interface StreamsDataStructure {

--- a/ui/src/types/streamTypes.ts
+++ b/ui/src/types/streamTypes.ts
@@ -23,7 +23,11 @@ export type MultiFilterCondition = {
 }
 
 export type StreamData = {
-	sync_mode: SyncMode.FULL_REFRESH | SyncMode.CDC | SyncMode.INCREMENTAL
+	sync_mode:
+		| SyncMode.FULL_REFRESH
+		| SyncMode.CDC
+		| SyncMode.INCREMENTAL
+		| SyncMode.STRICT_CDC
 	skip_nested_flattening?: boolean
 	cursor_field?: string[]
 	destination_sync_mode: string

--- a/ui/src/types/streamTypes.ts
+++ b/ui/src/types/streamTypes.ts
@@ -138,6 +138,7 @@ export interface SchemaConfigurationProps {
 	jobId?: number
 	destinationType?: string
 	jobName: string
+	onLoadingChange?: (isLoading: boolean) => void
 }
 
 export interface ExtendedStreamConfigurationProps

--- a/ui/src/utils/FormField.tsx
+++ b/ui/src/utils/FormField.tsx
@@ -1,10 +1,28 @@
+import { Tooltip } from "antd"
+import { Info } from "@phosphor-icons/react"
 import { FormFieldProps } from "../types"
 
-const FormField = ({ label, required, children, error }: FormFieldProps) => (
+const FormField = ({
+	label,
+	required,
+	children,
+	error,
+	tooltip,
+	info,
+}: FormFieldProps) => (
 	<div className="w-full">
-		<label className="mb-2 block text-sm font-medium text-gray-700">
+		<label className="mb-2 flex items-center gap-1 text-sm font-medium text-gray-700">
 			{label}
 			{required && <span className="text-red-500">*</span>}
+			{tooltip && (
+				<Tooltip title={tooltip}>
+					<Info
+						size={16}
+						className="ml-1 cursor-help text-slate-900"
+					/>
+				</Tooltip>
+			)}
+			{info}
 		</label>
 		{children}
 		{error && <div className="mt-1 text-sm text-red-500">{error}</div>}

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -271,6 +271,4 @@ export const LABELS = {
 export const FILTER_REGEX =
 	/^(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+)\s*(?:(and|or)\s*(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+))?\s*$/
 
-export const OLAKE_LATEST_VERSION = "v0.2.0-v0.2.1"
-
-export const OLAKE_LATEST_VERSION_URL = `https://olake.io/docs/release/${OLAKE_LATEST_VERSION}`
+export const OLAKE_LATEST_VERSION_URL = "https://olake.io/docs/release/overview"

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -251,6 +251,23 @@ export const LABELS = {
 	},
 } as const
 
+/**
+ * Matches a single or compound filter expression of the form:
+ *  - column operator value
+ *  - column operator value (and|or) column operator value
+ *
+ * Operators: >=, <=, !=, >, <, =
+ * Value can be a quoted string ("..."), a number (int/float), or a word (\w+)
+ *
+ * Capture groups:
+ *  1: first column name
+ *  2: first operator
+ *  3: first value
+ *  4: logical operator (and|or) [optional]
+ *  5: second column name [optional]
+ *  6: second operator [optional]
+ *  7: second value [optional]
+ */
 export const FILTER_REGEX =
 	/^(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+)\s*(?:(and|or)\s*(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+))?\s*$/
 

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -253,3 +253,7 @@ export const LABELS = {
 
 export const FILTER_REGEX =
 	/^(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+)\s*(?:(and|or)\s*(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+))?\s*$/
+
+export const OLAKE_LATEST_VERSION = "v0.2.0-v0.2.1"
+
+export const OLAKE_LATEST_VERSION_URL = `https://olake.io/docs/release/${OLAKE_LATEST_VERSION}`

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -250,3 +250,6 @@ export const LABELS = {
 		folderType: "Iceberg DB",
 	},
 } as const
+
+export const FILTER_REGEX =
+	/^(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+)\s*(?:(and|or)\s*(\w+)\s*(>=|<=|!=|>|<|=)\s*("[^"]+"|\d*\.?\d+|\w+))?\s*$/

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -509,14 +509,7 @@ export const handleSpecResponse = (
 	}
 }
 
-/**
- * Returns a copy of the selected streams map with all disabled streams removed.
- *
- * @param selectedStreams - Map from namespace to an array of streams,
- * each stream having a `disabled` flag.
- * @returns A new map with the same keys where each array only includes streams
- * that are not disabled.
- */
+// Returns a copy of the selected streams map with all disabled streams removed
 export const getSelectedStreams = (selectedStreams: {
 	[key: string]: SelectedStream[]
 }): { [key: string]: SelectedStream[] } => {

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { message } from "antd"
 import parser from "cron-parser"
 
-import { CronParseResult } from "../types"
+import { CronParseResult, SelectedStream } from "../types"
 import {
 	DAYS_MAP,
 	DESTINATION_INTERNAL_TYPES,
@@ -488,4 +488,15 @@ export const handleSpecResponse = (
 		setSchema({})
 		setUiSchema({})
 	}
+}
+
+export const getSelectedStreams = (selectedStreams: {
+	[key: string]: SelectedStream[]
+}): { [key: string]: SelectedStream[] } => {
+	return Object.fromEntries(
+		Object.entries(selectedStreams).map(([key, streams]) => [
+			key,
+			streams.filter(stream => !stream.disabled),
+		]),
+	)
 }

--- a/ui/src/utils/utils.ts
+++ b/ui/src/utils/utils.ts
@@ -6,6 +6,7 @@ import {
 	DAYS_MAP,
 	DESTINATION_INTERNAL_TYPES,
 	DESTINATION_LABELS,
+	FILTER_REGEX,
 } from "./constants"
 import MongoDB from "../assets/Mongo.svg"
 import Postgres from "../assets/Postgres.svg"
@@ -508,6 +509,14 @@ export const handleSpecResponse = (
 	}
 }
 
+/**
+ * Returns a copy of the selected streams map with all disabled streams removed.
+ *
+ * @param selectedStreams - Map from namespace to an array of streams,
+ * each stream having a `disabled` flag.
+ * @returns A new map with the same keys where each array only includes streams
+ * that are not disabled.
+ */
 export const getSelectedStreams = (selectedStreams: {
 	[key: string]: SelectedStream[]
 }): { [key: string]: SelectedStream[] } => {
@@ -516,5 +525,18 @@ export const getSelectedStreams = (selectedStreams: {
 			key,
 			streams.filter(stream => !stream.disabled),
 		]),
+	)
+}
+
+export const validateFilter = (filter: string): boolean => {
+	if (!filter.trim()) return false
+	return FILTER_REGEX.test(filter.trim())
+}
+
+export const validateStreams = (selections: {
+	[key: string]: SelectedStream[]
+}): boolean => {
+	return !Object.values(selections).some(streams =>
+		streams.some(sel => sel.filter && !validateFilter(sel.filter)),
 	)
 }


### PR DESCRIPTION
# Description

Improvements and bug fixes across job creation, source/destination configuration and logs.

- Normalization default enforced ON for relational DBs, independent of "Sync all" checkbox state.
- Filters now require both column and value when enabled; cannot proceed without completing required fields.
- Changing connector type clears previously selected existing source/destination to prevent invalid combinations.
- Stream configuration (enabled state and properties) now persists within the session when toggling streams off/on.
- Reset the streams when going back from stream configuration step.
- When changing connector type, version auto-selects to the latest available for the new type.
- In edit flows for specific source/destination entities, connector type and source name are disabled.
- Logs view no longer duplicates or mishandles entries on repeated refresh; consistent rendering after refresh.
- Added version tooltips:
   - Source tooltip: “Choose the Olake version for the source. For version details (link)”
   - Destination tooltip: “Choose the Olake version for the destination. For version details (link)”
   - Link points to release notes: OLake (v0.2.0 – v0.2.1)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Normalization default for relational DBs
- [x] Filter validation blocks progression until column+value set
- [x] Existing entity cleared on connector change
- [x] Stream config persists across toggles
- [x] Warning is displayed before going back from stream configuration and streams are reset if user goes back
- [x] Version resets to latest on type change
- [x] Edit-flow fields disabled (connector type, source name)
- [x] No duplicate messages on logs refresh
- [x] Version tooltips show with link to release notes

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->
<img width="1800" height="1007" alt="Screenshot 2025-09-25 at 2 21 49 PM" src="https://github.com/user-attachments/assets/c9ed7d12-82f5-420b-9deb-1d2f6c0f1396" />
<img width="1795" height="1012" alt="Screenshot 2025-09-25 at 2 22 49 PM" src="https://github.com/user-attachments/assets/e6df065a-4f24-4499-bd30-13c90d3fb710" />
<img width="1800" height="1004" alt="Screenshot 2025-09-25 at 2 23 05 PM" src="https://github.com/user-attachments/assets/52d455ae-965a-457d-828f-65299425c171" />
<img width="1800" height="958" alt="Screenshot 2025-09-25 at 2 23 36 PM" src="https://github.com/user-attachments/assets/ba7139c3-a7b9-4119-bed7-2f78bcb3c481" />
<img width="1797" height="921" alt="Screenshot 2025-09-25 at 2 24 10 PM" src="https://github.com/user-attachments/assets/9de4bf8a-cf4a-4a23-a2d7-5276f14092dc" />




## Related PR's (If Any):
N/A