### PR TITLE
fix: replace deprecated Phosphor icons with latest *Icon alternatives

### DIFF
--- a/ui/src/modules/auth/pages/Login.tsx
+++ b/ui/src/modules/auth/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { Form, Input, Button, Card, message } from "antd"
-import { User, LockKey } from "@phosphor-icons/react"
+import { UserIcon, LockKeyIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { LoginArgs } from "../../../types"
@@ -56,7 +56,7 @@ const Login: React.FC = () => {
 					>
 						<Input
 							prefix={
-								<User
+								<UserIcon
 									className="site-form-item-icon text-gray-500"
 									weight="bold"
 									size={18}
@@ -76,7 +76,7 @@ const Login: React.FC = () => {
 					>
 						<Input.Password
 							prefix={
-								<LockKey
+								<LockKeyIcon
 									className="site-form-item-icon text-gray-500"
 									weight="bold"
 									size={18}

--- a/ui/src/modules/common/Modals/ClearDataModal.tsx
+++ b/ui/src/modules/common/Modals/ClearDataModal.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom"
-import { Warning } from "@phosphor-icons/react"
+import { WarningIcon } from "@phosphor-icons/react"
 import { Button, message, Modal } from "antd"
 import { useAppStore } from "../../../store"
 
@@ -15,7 +15,7 @@ const ClearDataModal = () => {
 			centered
 		>
 			<div className="flex w-full flex-col items-center justify-center gap-8">
-				<Warning
+				<WarningIcon
 					className="size-16 text-danger"
 					weight="fill"
 				/>

--- a/ui/src/modules/common/Modals/ClearDestinationAndSyncModal.tsx
+++ b/ui/src/modules/common/Modals/ClearDestinationAndSyncModal.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom"
-import { Warning } from "@phosphor-icons/react"
+import { WarningIcon } from "@phosphor-icons/react"
 import { Button, message, Modal } from "antd"
 import { useAppStore } from "../../../store"
 
@@ -18,7 +18,7 @@ const ClearDestinationAndSyncModal = () => {
 			centered
 		>
 			<div className="flex w-full flex-col items-center justify-center gap-8">
-				<Warning
+				<WarningIcon
 					className="size-16 text-primary"
 					weight="fill"
 				/>

--- a/ui/src/modules/common/Modals/DeleteJobModal.tsx
+++ b/ui/src/modules/common/Modals/DeleteJobModal.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom"
 import { Button, message, Modal } from "antd"
-import { Warning } from "@phosphor-icons/react"
+import { WarningIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 
@@ -25,7 +25,7 @@ const DeleteJobModal = ({
 			centered
 		>
 			<div className="flex w-full flex-col items-center justify-center gap-8">
-				<Warning
+				<WarningIcon
 					className="size-16 text-danger"
 					weight="fill"
 				/>

--- a/ui/src/modules/common/Modals/DeleteModal.tsx
+++ b/ui/src/modules/common/Modals/DeleteModal.tsx
@@ -1,6 +1,6 @@
 import { formatDistanceToNow } from "date-fns"
 import { Button, message, Modal, Table } from "antd"
-import { Warning } from "@phosphor-icons/react"
+import { WarningIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { Entity } from "../../../types"
@@ -137,7 +137,7 @@ const DeleteModal = ({ fromSource }: DeleteModalProps) => {
 			width={600}
 		>
 			<div className="flex flex-col items-center justify-center gap-7 py-8">
-				<Warning
+				<WarningIcon
 					weight="fill"
 					className="h-[55px] w-[63px] text-danger"
 				/>

--- a/ui/src/modules/common/Modals/DestinationDatabaseModal.tsx
+++ b/ui/src/modules/common/Modals/DestinationDatabaseModal.tsx
@@ -8,7 +8,7 @@ import {
 	LABELS,
 	NAMESPACE_PLACEHOLDER,
 } from "../../../utils/constants"
-import { DotOutline } from "@phosphor-icons/react"
+import { DotOutlineIcon } from "@phosphor-icons/react"
 import { DestinationDatabaseModalProps } from "../../../types"
 
 type FormatType = (typeof FORMAT_OPTIONS)[keyof typeof FORMAT_OPTIONS]
@@ -171,7 +171,7 @@ const DestinationDatabaseModal = ({
 										key={index}
 										className="flex items-center text-sm"
 									>
-										<DotOutline
+										<DotOutlineIcon
 											size={24}
 											weight="fill"
 										/>

--- a/ui/src/modules/common/Modals/EditSourceModal.tsx
+++ b/ui/src/modules/common/Modals/EditSourceModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal, Table, message } from "antd"
-import { CheckCircle, Warning } from "@phosphor-icons/react"
+import { CheckCircleIcon, WarningIcon } from "@phosphor-icons/react"
 import { formatDistanceToNow } from "date-fns"
 import { useNavigate } from "react-router-dom"
 
@@ -75,7 +75,7 @@ const EditSourceModal = () => {
 			<Modal
 				title={
 					<div className="flex justify-center">
-						<Warning
+						<WarningIcon
 							weight="fill"
 							className="size-12 text-primary"
 						/>
@@ -183,7 +183,7 @@ const EditSourceModal = () => {
 				width={400}
 			>
 				<div className="flex flex-col items-center justify-center gap-7 py-6">
-					<CheckCircle
+					<CheckCircleIcon
 						weight="fill"
 						className="size-16 text-success"
 					/>

--- a/ui/src/modules/common/Modals/EntityCancelModal.tsx
+++ b/ui/src/modules/common/Modals/EntityCancelModal.tsx
@@ -1,7 +1,11 @@
 import React from "react"
 import { useNavigate } from "react-router-dom"
 import { Button, Modal } from "antd"
-import { GitCommit, LinktreeLogo, Path } from "@phosphor-icons/react"
+import {
+	GitCommitIcon,
+	LinktreeLogoIcon,
+	PathIcon,
+} from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { JOB_CREATION_STEPS } from "../../../utils/constants"
@@ -28,11 +32,11 @@ const EntityCancelModal: React.FC<EntityCancelModalProps> = ({
 			<div className="flex flex-col items-center justify-center gap-6 py-4">
 				<div className="rounded-xl bg-neutral-light p-2">
 					{type === JOB_CREATION_STEPS.SOURCE ? (
-						<LinktreeLogo className="z-10 size-6 text-text-link" />
+						<LinktreeLogoIcon className="z-10 size-6 text-text-link" />
 					) : type === JOB_CREATION_STEPS.DESTINATION ? (
-						<Path className="z-10 size-6 text-text-link" />
+						<PathIcon className="z-10 size-6 text-text-link" />
 					) : (
-						<GitCommit className="z-10 size-6 text-text-link" />
+						<GitCommitIcon className="z-10 size-6 text-text-link" />
 					)}
 				</div>
 				<div className="mb-4 text-center text-xl font-medium">

--- a/ui/src/modules/common/Modals/EntityEditModal.tsx
+++ b/ui/src/modules/common/Modals/EntityEditModal.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom"
 import { formatDistanceToNow } from "date-fns"
 import { Button, Modal, Table, message } from "antd"
-import { Warning } from "@phosphor-icons/react"
+import { WarningIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { sourceService } from "../../../api"
@@ -157,7 +157,7 @@ const EntityEditModal = ({ entityType }: EntityEditModalProps) => {
 			<Modal
 				title={
 					<div className="flex justify-center">
-						<Warning
+						<WarningIcon
 							weight="fill"
 							className="size-12 text-primary"
 						/>

--- a/ui/src/modules/common/Modals/EntitySavedModal.tsx
+++ b/ui/src/modules/common/Modals/EntitySavedModal.tsx
@@ -1,5 +1,10 @@
 import { useNavigate } from "react-router-dom"
-import { Check, GitCommit, Path, LinktreeLogo } from "@phosphor-icons/react"
+import {
+	CheckIcon,
+	GitCommitIcon,
+	PathIcon,
+	LinktreeLogoIcon,
+} from "@phosphor-icons/react"
 import { Button, Modal } from "antd"
 import { useAppStore } from "../../../store"
 import { EntitySavedModalProps } from "../../../types"
@@ -23,11 +28,11 @@ const EntitySavedModal: React.FC<EntitySavedModalProps> = ({
 			<div className="flex flex-col items-center justify-center gap-4 py-4">
 				<div className="rounded-xl bg-neutral-light p-2">
 					{type === "source" ? (
-						<LinktreeLogo className="z-10 size-5 text-text-link" />
+						<LinktreeLogoIcon className="z-10 size-5 text-text-link" />
 					) : type === JOB_CREATION_STEPS.STREAMS ? (
-						<GitCommit className="z-10 size-5 text-text-link" />
+						<GitCommitIcon className="z-10 size-5 text-text-link" />
 					) : (
-						<Path className="z-10 size-5 text-text-link" />
+						<PathIcon className="z-10 size-5 text-text-link" />
 					)}
 				</div>
 				<div className="mb-4 text-center text-xl font-medium">
@@ -40,11 +45,11 @@ const EntitySavedModal: React.FC<EntitySavedModalProps> = ({
 				<div className="mb-4 flex w-full items-center justify-between gap-3 rounded-xl border border-[#D9D9D9] px-4 py-2">
 					<div className="flex items-center gap-1">
 						{type === "source" ? (
-							<LinktreeLogo className="size-5" />
+							<LinktreeLogoIcon className="size-5" />
 						) : type === JOB_CREATION_STEPS.STREAMS ? (
-							<GitCommit className="size-5" />
+							<GitCommitIcon className="size-5" />
 						) : (
-							<Path className="size-5" />
+							<PathIcon className="size-5" />
 						)}
 						<span>
 							{entityName ||
@@ -56,7 +61,7 @@ const EntitySavedModal: React.FC<EntitySavedModalProps> = ({
 						</span>
 					</div>
 					<div className="flex gap-1 rounded-xl bg-[#f6ffed] px-2 py-1">
-						<Check className="size-5 text-success" />
+						<CheckIcon className="size-5 text-success" />
 						<span className="ml-auto text-success">Success</span>
 					</div>
 				</div>

--- a/ui/src/modules/common/Modals/TestConnectionFailureModal.tsx
+++ b/ui/src/modules/common/Modals/TestConnectionFailureModal.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom"
 import { Modal } from "antd"
-import { Info } from "@phosphor-icons/react"
+import { InfoIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import ErrorIcon from "../../../assets/ErrorIcon.svg"
@@ -54,7 +54,7 @@ const TestConnectionFailureModal = ({
 						Your test connection has failed
 					</h2>
 					<div className="mt-2 flex w-[360px] items-center gap-1 overflow-scroll rounded-xl bg-gray-50 p-3 text-xs">
-						<Info
+						<InfoIcon
 							weight="bold"
 							className="size-4 flex-shrink-0 text-danger"
 						/>

--- a/ui/src/modules/common/components/DocumentationPanel.tsx
+++ b/ui/src/modules/common/components/DocumentationPanel.tsx
@@ -2,10 +2,10 @@ import { useState, useRef, useEffect } from "react"
 import clsx from "clsx"
 import { Button, Tooltip } from "antd"
 import {
-	CornersOut,
-	CaretRight,
-	Info,
-	ArrowSquareOut,
+	CornersOutIcon,
+	CaretRightIcon,
+	InfoIcon,
+	ArrowSquareOutIcon,
 } from "@phosphor-icons/react"
 
 import { DocumentationPanelProps } from "../../../types"
@@ -78,7 +78,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
 					className="flex items-center"
 					onClick={openInNewTab}
 					icon={
-						<ArrowSquareOut
+						<ArrowSquareOutIcon
 							size={16}
 							className="mr-2"
 						/>
@@ -91,7 +91,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
 					className="flex items-center bg-blue-600"
 					onClick={toggleDocPanel}
 					icon={
-						<CornersOut
+						<CornersOutIcon
 							size={16}
 							className="mr-2"
 						/>
@@ -120,7 +120,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
 								isDocPanelCollapsed ? "rotate-180" : "rotate-0",
 							)}
 						>
-							<CaretRight size={16} />
+							<CaretRightIcon size={16} />
 						</div>
 					</button>
 				</div>
@@ -144,7 +144,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
 							<Button
 								type="default"
 								icon={
-									<ArrowSquareOut
+									<ArrowSquareOutIcon
 										size={20}
 										weight="bold"
 										className="text-primary"
@@ -173,7 +173,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
 						<div className="flex h-full w-full items-start justify-center">
 							<div className="absolute right-3 top-10 z-10 flex flex-col gap-2">
 								<div className="rounded-xl border border-gray-200 bg-neutral-light p-2">
-									<Info
+									<InfoIcon
 										size={25}
 										className="cursor-pointer text-primary transition-all duration-300 ease-in-out hover:text-primary/80"
 										onClick={toggleDocPanel}
@@ -184,7 +184,7 @@ const DocumentationPanel: React.FC<DocumentationPanelProps> = ({
 										title="Open documentation in new tab"
 										placement="left"
 									>
-										<ArrowSquareOut
+										<ArrowSquareOutIcon
 											size={25}
 											className="cursor-pointer text-primary transition-all duration-300 ease-in-out hover:text-primary/80"
 											onClick={openInNewTab}

--- a/ui/src/modules/common/components/Form/ArrayFieldTemplate.tsx
+++ b/ui/src/modules/common/components/Form/ArrayFieldTemplate.tsx
@@ -1,6 +1,6 @@
 import { ArrayFieldTemplateProps } from "@rjsf/utils"
 import { Button } from "antd"
-import { Plus, Trash } from "@phosphor-icons/react"
+import { PlusIcon, TrashIcon } from "@phosphor-icons/react"
 
 const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
 	const { items, canAdd, onAddClick } = props
@@ -21,7 +21,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
 									type="text"
 									danger
 									onClick={item.onDropIndexClick(item.index)}
-									icon={<Trash className="text-red-500" />}
+									icon={<TrashIcon className="text-red-500" />}
 								/>
 							)}
 						</div>
@@ -36,7 +36,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
 						size="middle"
 						className="px-3"
 						onClick={onAddClick}
-						icon={<Plus className="size-4" />}
+						icon={<PlusIcon className="size-4" />}
 					>
 						Add
 					</Button>

--- a/ui/src/modules/common/components/Form/CustomFieldTemplate.tsx
+++ b/ui/src/modules/common/components/Form/CustomFieldTemplate.tsx
@@ -1,5 +1,5 @@
 import { FieldTemplateProps } from "@rjsf/utils"
-import { Info, Plus, Trash } from "@phosphor-icons/react"
+import { InfoIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react"
 import { Tooltip, Button } from "antd"
 import { useState, useEffect } from "react"
 
@@ -42,7 +42,7 @@ function KeyValueRow({
 			<Button
 				type="text"
 				onClick={() => onDelete(keyName)}
-				icon={<Trash className="text-red-500" />}
+				icon={<TrashIcon className="text-red-500" />}
 			/>
 		</div>
 	)
@@ -81,7 +81,7 @@ function NewKeyValueRow({
 			<Button
 				type="text"
 				onClick={onAdd}
-				icon={<Plus className="text-blue-500" />}
+				icon={<PlusIcon className="text-blue-500" />}
 			/>
 		</div>
 	)
@@ -221,7 +221,7 @@ export default function CustomFieldTemplate(props: FieldTemplateProps) {
 							title={description || rawDescription}
 							placement="right"
 						>
-							<Info className="ml-1 text-gray-500 hover:text-gray-600" />
+							<InfoIcon className="ml-1 text-gray-500 hover:text-gray-600" />
 						</Tooltip>
 					)}
 				</label>

--- a/ui/src/modules/common/components/Layout.tsx
+++ b/ui/src/modules/common/components/Layout.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import clsx from "clsx"
 import { NavLink, Link, useNavigate } from "react-router-dom"
 import { LayoutProps } from "antd"
-import { CaretLeft, Info, X, SignOut } from "@phosphor-icons/react"
+import { CaretLeftIcon, InfoIcon, X, SignOutIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { NAV_ITEMS } from "../../../utils/constants"
@@ -22,7 +22,7 @@ const UpdateNotification: React.FC<{ onClose: () => void }> = ({ onClose }) => (
 				/>
 			</button>
 			<div className="flex items-center gap-2">
-				<Info
+				<InfoIcon
 					weight="fill"
 					size={17}
 					color="#203FDD"
@@ -105,7 +105,7 @@ const Sidebar: React.FC<{
 					onClick={onLogout}
 					className="flex w-full items-center rounded-xl p-3 text-gray-700 hover:bg-gray-100 hover:text-black"
 				>
-					<SignOut
+					<SignOutIcon
 						className="mr-3 flex-shrink-0"
 						size={20}
 					/>
@@ -123,7 +123,7 @@ const Sidebar: React.FC<{
 						collapsed ? "rotate-180" : "rotate-0",
 					)}
 				>
-					<CaretLeft size={16} />
+					<CaretLeftIcon size={16} />
 				</div>
 			</button>
 		</div>

--- a/ui/src/modules/destinations/components/DestinationEmptyState.tsx
+++ b/ui/src/modules/destinations/components/DestinationEmptyState.tsx
@@ -1,5 +1,5 @@
 import { Button } from "antd"
-import { PlayCircle, Plus } from "@phosphor-icons/react"
+import { PlayCircleIcon, PlusIcon } from "@phosphor-icons/react"
 
 import { DestinationTutorialYTLink } from "../../../utils/constants"
 import FirstDestination from "../../../assets/FirstDestination.svg"
@@ -29,7 +29,7 @@ const DestinationEmptyState = ({
 				className="border-1 mb-12 border-[1px] border-[#D9D9D9] bg-white px-6 py-4 text-black"
 				onClick={handleCreateDestination}
 			>
-				<Plus />
+				<PlusIcon />
 				New Destination
 			</Button>
 			<div className="w-[412px] rounded-xl border-[1px] border-[#D9D9D9] bg-white p-4 shadow-sm">
@@ -48,7 +48,7 @@ const DestinationEmptyState = ({
 					</a>
 					<div className="flex-1">
 						<div className="mb-1 flex items-center gap-1 text-xs">
-							<PlayCircle color="#9f9f9f" />
+							<PlayCircleIcon color="#9f9f9f" />
 							<span className="text-text-placeholder">OLake/ Tutorial</span>
 						</div>
 						<div className="text-xs">

--- a/ui/src/modules/destinations/components/DestinationTable.tsx
+++ b/ui/src/modules/destinations/components/DestinationTable.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react"
 import { Table, Input, Button, Dropdown, Pagination } from "antd"
-import { DotsThree, PencilSimpleLine, Trash } from "@phosphor-icons/react"
+import {
+	DotsThreeIcon,
+	PencilSimpleLineIcon,
+	TrashIcon,
+} from "@phosphor-icons/react"
 
 import { DestinationTableProps, Entity } from "../../../types"
 import { getConnectorImage } from "../../../utils/utils"
@@ -31,13 +35,13 @@ const DestinationTable: React.FC<DestinationTableProps> = ({
 						items: [
 							{
 								key: "edit",
-								icon: <PencilSimpleLine className="size-4" />,
+								icon: <PencilSimpleLineIcon className="size-4" />,
 								label: "Edit",
 								onClick: () => onEdit(String(record.id)),
 							},
 							{
 								key: "delete",
-								icon: <Trash className="size-4" />,
+								icon: <TrashIcon className="size-4" />,
 								label: "Delete",
 								danger: true,
 								onClick: () => onDelete(record),
@@ -49,7 +53,7 @@ const DestinationTable: React.FC<DestinationTableProps> = ({
 				>
 					<Button
 						type="text"
-						icon={<DotsThree className="size-5" />}
+						icon={<DotsThreeIcon className="size-5" />}
 					/>
 				</Dropdown>
 			),

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -7,7 +7,12 @@ import {
 } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { Input, message, Select, Spin } from "antd"
-import { ArrowLeft, ArrowRight, Info, Notebook } from "@phosphor-icons/react"
+import {
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	InfoIcon,
+	NotebookIcon,
+} from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 
 import { useAppStore } from "../../../store"
@@ -498,7 +503,7 @@ const CreateDestination = forwardRef<
 									/>
 								) : (
 									<div className="flex items-center gap-1 text-sm text-red-500">
-										<Info />
+										<InfoIcon />
 										No versions available
 									</div>
 								)}
@@ -615,7 +620,7 @@ const CreateDestination = forwardRef<
 								to={"/destinations"}
 								className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 							>
-								<ArrowLeft className="mr-1 size-5" />
+								<ArrowLeftIcon className="mr-1 size-5" />
 							</Link>
 							<div className="text-lg font-bold">Create destination</div>
 						</div>
@@ -633,7 +638,7 @@ const CreateDestination = forwardRef<
 								<div className="mb-6 mt-2 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
 									<div>
 										<div className="mb-4 flex items-center gap-2 text-base font-medium">
-											<Notebook className="size-5" />
+											<NotebookIcon className="size-5" />
 											Capture information
 										</div>
 
@@ -663,7 +668,7 @@ const CreateDestination = forwardRef<
 										}}
 									>
 										Create
-										<ArrowRight className="size-4 text-white" />
+										<ArrowRightIcon className="size-4 text-white" />
 									</button>
 								</div>
 							)}

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -3,7 +3,12 @@ import { useParams, Link, useNavigate } from "react-router-dom"
 import { formatDistanceToNow } from "date-fns"
 import { Input, Button, Select, Switch, message, Spin, Table } from "antd"
 import type { ColumnsType } from "antd/es/table"
-import { ArrowLeft, Info, Notebook, PencilSimple } from "@phosphor-icons/react"
+import {
+	ArrowLeftIcon,
+	InfoIcon,
+	NotebookIcon,
+	PencilSimpleIcon,
+} from "@phosphor-icons/react"
 import validator from "@rjsf/validator-ajv8"
 import Form from "@rjsf/antd"
 
@@ -464,7 +469,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 		<div className="rounded-lg">
 			<div className="mb-6 rounded-xl border border-[#D9D9D9] p-6">
 				<div className="mb-4 flex items-center gap-1 text-lg font-medium">
-					<Notebook className="size-5" />
+					<NotebookIcon className="size-5" />
 					Capture information
 				</div>
 
@@ -506,7 +511,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 								/>
 							) : (
 								<div className="flex items-center gap-1 text-sm text-red-500">
-									<Info />
+									<InfoIcon />
 									No versions available
 								</div>
 							)}
@@ -614,7 +619,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 							to="/destinations"
 							className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 						>
-							<ArrowLeft className="size-5" />
+							<ArrowLeftIcon className="size-5" />
 						</Link>
 						<div className="text-lg font-bold">{destinationName}</div>
 					</div>
@@ -638,7 +643,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 											}
 											className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-white hover:bg-primary-600"
 										>
-											<PencilSimple className="size-4" />
+											<PencilSimpleIcon className="size-4" />
 											Edit Destination
 										</Link>
 									</div>

--- a/ui/src/modules/destinations/pages/Destinations.tsx
+++ b/ui/src/modules/destinations/pages/Destinations.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
-import { Path, Plus } from "@phosphor-icons/react"
+import { PathIcon, PlusIcon } from "@phosphor-icons/react"
 import { Button, Tabs, Empty, message, Spin } from "antd"
 
 import analyticsService from "../../../api/services/analyticsService"
@@ -99,14 +99,14 @@ const Destinations: React.FC = () => {
 		<div className="p-6">
 			<div className="mb-4 flex items-center justify-between">
 				<div className="flex items-center">
-					<Path className="mr-2 size-6" />
+					<PathIcon className="mr-2 size-6" />
 					<h1 className="text-2xl font-bold">Destinations</h1>
 				</div>
 				<button
 					onClick={handleCreateDestination}
 					className="flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white hover:bg-primary-600"
 				>
-					<Plus className="size-4 text-white" />
+					<PlusIcon className="size-4 text-white" />
 					Create Destination
 				</button>
 			</div>

--- a/ui/src/modules/jobs/components/JobConfiguration.tsx
+++ b/ui/src/modules/jobs/components/JobConfiguration.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { Input, Select, Radio, Tooltip } from "antd"
-import { Info } from "@phosphor-icons/react"
+import { InfoIcon } from "@phosphor-icons/react"
 import parser from "cron-parser"
 import { useLocation } from "react-router-dom"
 
@@ -215,7 +215,7 @@ const JobConfiguration: React.FC<JobConfigurationProps> = ({
 									<div className="mb-2 flex items-center gap-1">
 										<label className="block text-sm">Cron Expression</label>
 										<Tooltip title="Cron format: minute hour day month weekday. Example: 0 0 * * * runs every day at midnight.">
-											<Info
+											<InfoIcon
 												size={16}
 												className="cursor-help text-slate-900"
 											/>

--- a/ui/src/modules/jobs/components/JobEmptyState.tsx
+++ b/ui/src/modules/jobs/components/JobEmptyState.tsx
@@ -1,5 +1,5 @@
 import { Button } from "antd"
-import { GitCommit, PlayCircle } from "@phosphor-icons/react"
+import { GitCommitIcon, PlayCircleIcon } from "@phosphor-icons/react"
 
 import { JobTutorialYTLink } from "../../../utils/constants"
 import FirstJob from "../../../assets/FirstJob.svg"
@@ -27,7 +27,7 @@ const JobEmptyState = ({
 				className="mb-12 bg-brand-blue text-sm"
 				onClick={handleCreateJob}
 			>
-				<GitCommit />
+				<GitCommitIcon />
 				Create your first Job
 			</Button>
 			<div className="w-[412px] rounded-xl border-[1px] border-[#D9D9D9] bg-white p-6 shadow-sm">
@@ -46,7 +46,7 @@ const JobEmptyState = ({
 					</a>
 					<div className="flex-1">
 						<div className="mb-1 flex items-center gap-1 text-xs">
-							<PlayCircle color="#9f9f9f" />
+							<PlayCircleIcon color="#9f9f9f" />
 							<span className="text-text-placeholder">OLake/ Tutorial</span>
 						</div>
 						<div className="text-xs">

--- a/ui/src/modules/jobs/components/JobTable.tsx
+++ b/ui/src/modules/jobs/components/JobTable.tsx
@@ -3,14 +3,14 @@ import { useNavigate } from "react-router-dom"
 import { formatDistanceToNow } from "date-fns"
 import { Table, Input, Button, Dropdown, Pagination } from "antd"
 import {
-	ArrowsClockwise,
-	ClockCounterClockwise,
-	DotsThree,
-	Gear,
-	Pause,
-	PencilSimple,
-	Play,
-	Trash,
+	ArrowsClockwiseIcon,
+	ClockCounterClockwiseIcon,
+	DotsThreeIcon,
+	GearIcon,
+	PauseIcon,
+	PencilSimpleIcon,
+	PlayIcon,
+	TrashIcon,
 } from "@phosphor-icons/react"
 
 import { EntityBase, Job, JobTableProps } from "../../../types"
@@ -65,13 +65,13 @@ const JobTable: React.FC<JobTableProps> = ({
 						? [
 								{
 									key: "edit",
-									icon: <PencilSimple className="size-4" />,
+									icon: <PencilSimpleIcon className="size-4" />,
 									label: "Edit",
 									onClick: () => onEdit(record.id.toString()),
 								},
 								{
 									key: "delete",
-									icon: <Trash className="size-4" />,
+									icon: <TrashIcon className="size-4" />,
 									label: "Delete",
 									danger: true,
 									onClick: () => onDelete(record.id.toString()),
@@ -80,41 +80,41 @@ const JobTable: React.FC<JobTableProps> = ({
 						: [
 								{
 									key: "sync",
-									icon: <ArrowsClockwise className="size-4" />,
+									icon: <ArrowsClockwiseIcon className="size-4" />,
 									label: "Sync now",
 									onClick: () => onSync(record.id.toString()),
 								},
 								{
 									key: "edit",
-									icon: <PencilSimple className="size-4" />,
+									icon: <PencilSimpleIcon className="size-4" />,
 									label: "Edit Streams",
 									onClick: () => onEdit(record.id.toString()),
 								},
 								{
 									key: "pause",
 									icon: record.activate ? (
-										<Pause className="size-4" />
+										<PauseIcon className="size-4" />
 									) : (
-										<Play className="size-4" />
+										<PlayIcon className="size-4" />
 									),
 									label: record.activate ? "Pause job" : "Resume job",
 									onClick: () => onPause(record.id.toString(), record.activate),
 								},
 								{
 									key: "history",
-									icon: <ClockCounterClockwise className="size-4" />,
+									icon: <ClockCounterClockwiseIcon className="size-4" />,
 									label: "Job Logs & History",
 									onClick: () => handleViewHistory(record.id.toString()),
 								},
 								{
 									key: "settings",
-									icon: <Gear className="size-4" />,
+									icon: <GearIcon className="size-4" />,
 									label: "Job settings",
 									onClick: () => handleViewSettings(record.id.toString()),
 								},
 								{
 									key: "delete",
-									icon: <Trash className="size-4" />,
+									icon: <TrashIcon className="size-4" />,
 									label: "Delete",
 									danger: true,
 									onClick: () => onDelete(record.id.toString()),
@@ -129,7 +129,7 @@ const JobTable: React.FC<JobTableProps> = ({
 					>
 						<Button
 							type="text"
-							icon={<DotsThree className="size-5" />}
+							icon={<DotsThreeIcon className="size-5" />}
 						/>
 					</Dropdown>
 				)

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -1,7 +1,11 @@
 import { useState, useRef } from "react"
 import { useNavigate, Link, useLocation } from "react-router-dom"
 import { message } from "antd"
-import { ArrowLeft, ArrowRight, DownloadSimple } from "@phosphor-icons/react"
+import {
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	DownloadSimpleIcon,
+} from "@phosphor-icons/react"
 import { v4 as uuidv4 } from "uuid"
 
 import { useAppStore } from "../../../store"
@@ -361,7 +365,7 @@ const JobCreation: React.FC = () => {
 							to="/jobs"
 							className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 						>
-							<ArrowLeft className="mr-1 size-5" />
+							<ArrowLeftIcon className="mr-1 size-5" />
 						</Link>
 
 						<div className="text-2xl font-bold"> Create Job</div>
@@ -487,7 +491,7 @@ const JobCreation: React.FC = () => {
 						onClick={handleSaveJob}
 						className="flex items-center justify-center gap-2 rounded-md border border-gray-400 px-4 py-1 font-light hover:bg-[#ebebeb]"
 					>
-						<DownloadSimple className="size-4" />
+						<DownloadSimpleIcon className="size-4" />
 						Save Job
 					</button>
 				</div>
@@ -507,7 +511,7 @@ const JobCreation: React.FC = () => {
 						onClick={handleNext}
 					>
 						{currentStep === JOB_CREATION_STEPS.STREAMS ? "Create Job" : "Next"}
-						<ArrowRight className="size-4 text-white" />
+						<ArrowRightIcon className="size-4 text-white" />
 					</button>
 					<TestConnectionModal />
 					<TestConnectionSuccessModal />

--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react"
 import clsx from "clsx"
 import { useNavigate, Link, useParams } from "react-router-dom"
 import { message } from "antd"
-import { ArrowLeft, ArrowRight } from "@phosphor-icons/react"
+import { ArrowLeftIcon, ArrowRightIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { jobService } from "../../../api"
@@ -408,7 +408,7 @@ const JobEdit: React.FC = () => {
 							to="/jobs"
 							className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 						>
-							<ArrowLeft className="mr-1 size-5" />
+							<ArrowLeftIcon className="mr-1 size-5" />
 						</Link>
 						<div className="text-2xl font-bold">
 							{jobName ? (jobName === "-" ? " " : jobName) : "New Job"}
@@ -537,7 +537,7 @@ const JobEdit: React.FC = () => {
 								: "Finish"
 							: "Next"}
 						{currentStep !== JOB_CREATION_STEPS.STREAMS && (
-							<ArrowRight className="size-4 text-white" />
+							<ArrowRightIcon className="size-4 text-white" />
 						)}
 					</button>
 				</div>

--- a/ui/src/modules/jobs/pages/JobHistory.tsx
+++ b/ui/src/modules/jobs/pages/JobHistory.tsx
@@ -3,10 +3,10 @@ import clsx from "clsx"
 import { useParams, useNavigate, Link } from "react-router-dom"
 import { Table, Button, Input, Spin, message, Pagination, Tooltip } from "antd"
 import {
-	ArrowLeft,
-	ArrowRight,
-	ArrowsClockwise,
-	Eye,
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	ArrowsClockwiseIcon,
+	EyeIcon,
 } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
@@ -125,7 +125,7 @@ const JobHistory: React.FC = () => {
 			render: (_: any, record: any) => (
 				<Button
 					type="default"
-					icon={<Eye size={16} />}
+					icon={<EyeIcon size={16} />}
 					onClick={() => handleViewLogs(record.file_path)}
 				>
 					View logs
@@ -163,7 +163,7 @@ const JobHistory: React.FC = () => {
 							to="/jobs"
 							className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 						>
-							<ArrowLeft className="size-5" />
+							<ArrowLeftIcon className="size-5" />
 						</Link>
 
 						<div className="flex flex-col items-start">
@@ -206,7 +206,7 @@ const JobHistory: React.FC = () => {
 					/>
 					<Tooltip title="Click to refetch">
 						<Button
-							icon={<ArrowsClockwise size={16} />}
+							icon={<ArrowsClockwiseIcon size={16} />}
 							onClick={() => {
 								if (jobId) {
 									fetchJobTasks(jobId).catch(error => {
@@ -270,7 +270,7 @@ const JobHistory: React.FC = () => {
 					onClick={() => navigate(`/jobs/${jobId}/settings`)}
 				>
 					View job configurations
-					<ArrowRight size={16} />
+					<ArrowRightIcon size={16} />
 				</Button>
 			</div>
 		</div>

--- a/ui/src/modules/jobs/pages/JobLogs.tsx
+++ b/ui/src/modules/jobs/pages/JobLogs.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from "react"
 import clsx from "clsx"
 import { useParams, useNavigate, Link, useSearchParams } from "react-router-dom"
 import { Input, Spin, message, Button, Tooltip } from "antd"
-import { ArrowLeft, ArrowRight, ArrowsClockwise } from "@phosphor-icons/react"
+import {
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	ArrowsClockwiseIcon,
+} from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import {
@@ -122,7 +126,7 @@ const JobLogs: React.FC = () => {
 									to={`/jobs/${jobId}/history`}
 									className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 								>
-									<ArrowLeft className="size-5" />
+									<ArrowLeftIcon className="size-5" />
 								</Link>
 							</div>
 							<div className="flex flex-col items-start">
@@ -166,7 +170,7 @@ const JobLogs: React.FC = () => {
 					/>
 					<Tooltip title="Click to refetch the logs">
 						<Button
-							icon={<ArrowsClockwise size={16} />}
+							icon={<ArrowsClockwiseIcon size={16} />}
 							onClick={() => {
 								if (isTaskLog && filePath) {
 									fetchTaskLogs(jobId!, historyId || "1", filePath)
@@ -291,7 +295,7 @@ const JobLogs: React.FC = () => {
 					onClick={() => navigate(`/jobs/${jobId}/settings`)}
 				>
 					View job configurations
-					<ArrowRight size={16} />
+					<ArrowRightIcon size={16} />
 				</Button>
 			</div>
 		</div>

--- a/ui/src/modules/jobs/pages/JobSettings.tsx
+++ b/ui/src/modules/jobs/pages/JobSettings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { useParams, Link, useNavigate } from "react-router-dom"
 import { Input, Button, Switch, message, Select, Radio, Tooltip } from "antd"
-import { Info, ArrowLeft } from "@phosphor-icons/react"
+import { InfoIcon, ArrowLeftIcon } from "@phosphor-icons/react"
 import parser from "cron-parser"
 
 import { useAppStore } from "../../../store"
@@ -273,7 +273,7 @@ const JobSettings: React.FC = () => {
 										to="/jobs"
 										className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 									>
-										<ArrowLeft className="size-5" />
+										<ArrowLeftIcon className="size-5" />
 									</Link>
 
 									<div className="text-2xl font-bold">{job?.name}</div>
@@ -341,7 +341,7 @@ const JobSettings: React.FC = () => {
 															Cron Expression
 														</label>
 														<Tooltip title="Cron format: minute hour day month weekday. Example: 0 0 * * * runs every day at midnight.">
-															<Info
+															<InfoIcon
 																size={16}
 																className="cursor-help text-slate-900"
 															/>

--- a/ui/src/modules/jobs/pages/Jobs.tsx
+++ b/ui/src/modules/jobs/pages/Jobs.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
 import { Button, Tabs, Empty, message, Spin } from "antd"
-import { GitCommit, Plus } from "@phosphor-icons/react"
+import { GitCommitIcon, PlusIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import { jobService } from "../../../api"
@@ -167,14 +167,14 @@ const Jobs: React.FC = () => {
 		<div className="p-6">
 			<div className="mb-4 flex items-center justify-between">
 				<div className="flex items-center gap-2">
-					<GitCommit className="mr-2 size-6" />
+					<GitCommitIcon className="mr-2 size-6" />
 					<h1 className="text-2xl font-bold">Jobs</h1>
 				</div>
 				<button
 					className="flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white hover:bg-primary-600"
 					onClick={handleCreateJob}
 				>
-					<Plus className="size-4 text-white" />
+					<PlusIcon className="size-4 text-white" />
 					Create Job
 				</button>
 			</div>

--- a/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/SchemaConfiguration.tsx
@@ -13,7 +13,11 @@ import FilterButton from "../components/FilterButton"
 import StepTitle from "../../common/components/StepTitle"
 import StreamsCollapsibleList from "./streams/StreamsCollapsibleList"
 import StreamConfiguration from "./streams/StreamConfiguration"
-import { ArrowSquareOut, Info, PencilSimple } from "@phosphor-icons/react"
+import {
+	ArrowSquareOutIcon,
+	InfoIcon,
+	PencilSimpleIcon,
+} from "@phosphor-icons/react"
 import {
 	DESTINATION_INTERNAL_TYPES,
 	DESTINATATION_DATABASE_TOOLTIP_TEXT,
@@ -574,7 +578,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 								<div className="absolute -right-2 -top-2">
 									<Tooltip title={DESTINATATION_DATABASE_TOOLTIP_TEXT}>
 										<div className="rounded-full bg-white p-1 shadow-sm ring-1 ring-gray-100">
-											<Info className="size-4 cursor-help text-primary" />
+											<InfoIcon className="size-4 cursor-help text-primary" />
 										</div>
 									</Tooltip>
 								</div>
@@ -596,7 +600,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 												title="Edit"
 												placement="top"
 											>
-												<PencilSimple
+												<PencilSimpleIcon
 													className="size-4 cursor-pointer text-gray-600 transition-colors hover:text-primary"
 													onClick={() => setShowDestinationDatabaseModal(true)}
 												/>
@@ -609,7 +613,7 @@ const SchemaConfiguration: React.FC<SchemaConfigurationProps> = ({
 												rel="noopener noreferrer"
 												className="flex items-center text-gray-600 transition-colors hover:text-primary"
 											>
-												<ArrowSquareOut className="size-4" />
+												<ArrowSquareOutIcon className="size-4" />
 											</a>
 										</Tooltip>
 									</div>

--- a/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamConfiguration.tsx
@@ -3,14 +3,14 @@ import { formatDestinationPath } from "../../../../utils/destination-database"
 import clsx from "clsx"
 import { Button, Divider, Input, Radio, Select, Switch, Tooltip } from "antd"
 import {
-	ColumnsPlusRight,
-	GridFour,
-	Info,
-	Lightning,
-	Plus,
-	SlidersHorizontal,
-	X,
-	ArrowSquareOut,
+	ColumnsPlusRightIcon,
+	GridFourIcon,
+	InfoIcon,
+	LightningIcon,
+	PlusIcon,
+	SlidersHorizontalIcon,
+	XIcon,
+	ArrowSquareOutIcon,
 } from "@phosphor-icons/react"
 
 import {
@@ -585,7 +585,7 @@ const StreamConfiguration = ({
 											<label className="mb-1 flex items-center gap-1 font-medium text-neutral-text">
 												Cursor field:
 												<Tooltip title="Column for identifying new/updated records ">
-													<Info className="size-3.5 cursor-pointer" />
+													<InfoIcon className="size-3.5 cursor-pointer" />
 												</Tooltip>
 											</label>
 											<Select
@@ -623,7 +623,7 @@ const StreamConfiguration = ({
 													<Tooltip title="Alternative cursor column in case cursor column encounters null values">
 														<Button
 															type="default"
-															icon={<Plus className="size-4" />}
+															icon={<PlusIcon className="size-4" />}
 															onClick={() => setShowFallbackSelector(true)}
 															className="mb-[2px] flex items-center gap-1"
 														>
@@ -639,7 +639,7 @@ const StreamConfiguration = ({
 													<label className="mb-1 flex items-center gap-1 font-medium text-neutral-text">
 														Fallback Cursor:
 														<Tooltip title="Alternative cursor column in case cursor column encounters null values">
-															<Info className="size-3.5 cursor-pointer text-neutral-text" />
+															<InfoIcon className="size-3.5 cursor-pointer text-neutral-text" />
 														</Tooltip>
 													</label>
 													<Select
@@ -709,7 +709,7 @@ const StreamConfiguration = ({
 				</div>
 				{!isSelected && (
 					<div className="ml-1 flex items-center gap-1 text-sm text-[#686868]">
-						<Info className="size-4" />
+						<InfoIcon className="size-4" />
 						Select the stream to configure Normalization
 					</div>
 				)}
@@ -738,7 +738,7 @@ const StreamConfiguration = ({
 				</div>
 				{!isSelected && (
 					<div className="ml-1 flex items-center gap-1 text-sm text-[#686868]">
-						<Info className="size-4" />
+						<InfoIcon className="size-4" />
 						Select the stream to configure Data Filter
 					</div>
 				)}
@@ -758,7 +758,7 @@ const StreamConfiguration = ({
 				<div className="text-neutral-text">Partitioning regex:</div>
 
 				<Tooltip title={PartitioningRegexTooltip}>
-					<Info className="size-5 cursor-help items-center pt-1 text-gray-500" />
+					<InfoIcon className="size-5 cursor-help items-center pt-1 text-gray-500" />
 				</Tooltip>
 				<a
 					href={
@@ -770,7 +770,7 @@ const StreamConfiguration = ({
 					rel="noopener noreferrer"
 					className="flex items-center text-primary hover:text-primary/80"
 				>
-					<ArrowSquareOut className="size-5" />
+					<ArrowSquareOutIcon className="size-5" />
 				</a>
 			</div>
 			{isSelected ? (
@@ -813,7 +813,7 @@ const StreamConfiguration = ({
 				</>
 			) : (
 				<div className="ml-1 flex items-center gap-1 text-sm text-[#686868]">
-					<Info className="size-4" />
+					<InfoIcon className="size-4" />
 					Select the stream to configure Partitioning
 				</div>
 			)}
@@ -857,7 +857,7 @@ const StreamConfiguration = ({
 							<Button
 								type="text"
 								danger
-								icon={<X className="size-4" />}
+								icon={<XIcon className="size-4" />}
 								onClick={() => handleRemoveFilter(index)}
 								disabled={isStreamInInitialSelection}
 							>
@@ -871,7 +871,7 @@ const StreamConfiguration = ({
 						</div>
 						{index === 0 && (
 							<div className="mb-4 flex items-center gap-1 rounded-lg bg-warning-light p-2 text-warning-light">
-								<Lightning className="size-4 font-bold text-warning" />
+								<LightningIcon className="size-4 font-bold text-warning" />
 								<div className="text-warning-dark">
 									Selecting indexed columns will enhance performance
 								</div>
@@ -928,7 +928,7 @@ const StreamConfiguration = ({
 			{multiFilterCondition.conditions.length < 2 && (
 				<Button
 					type="default"
-					icon={<Plus className="size-4" />}
+					icon={<PlusIcon className="size-4" />}
 					onClick={handleAddFilter}
 					className="w-fit"
 					disabled={isStreamInInitialSelection}
@@ -958,7 +958,7 @@ const StreamConfiguration = ({
 								<div className="flex items-center whitespace-nowrap font-medium">
 									Destination Table{" "}
 									<Tooltip title={DESTINATION_TABLE_TOOLTIP_TEXT}>
-										<Info className="size-5 cursor-help items-center px-0.5 text-gray-500" />
+										<InfoIcon className="size-5 cursor-help items-center px-0.5 text-gray-500" />
 									</Tooltip>{" "}
 									:
 								</div>
@@ -980,17 +980,17 @@ const StreamConfiguration = ({
 					<TabButton
 						id="config"
 						label="Config"
-						icon={<SlidersHorizontal className="size-3.5" />}
+						icon={<SlidersHorizontalIcon className="size-3.5" />}
 					/>
 					<TabButton
 						id="schema"
 						label="Schema"
-						icon={<ColumnsPlusRight className="size-3.5" />}
+						icon={<ColumnsPlusRightIcon className="size-3.5" />}
 					/>
 					<TabButton
 						id="partitioning"
 						label="Partitioning"
-						icon={<GridFour className="size-3.5" />}
+						icon={<GridFourIcon className="size-3.5" />}
 					/>
 				</div>
 			</div>

--- a/ui/src/modules/jobs/pages/streams/StreamHeader.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamHeader.tsx
@@ -1,4 +1,4 @@
-import { CaretRight } from "@phosphor-icons/react"
+import { CaretRightIcon } from "@phosphor-icons/react"
 import { Checkbox, CheckboxChangeEvent } from "antd"
 import clsx from "clsx"
 
@@ -50,7 +50,7 @@ const StreamHeader: React.FC<StreamHeaderProps> = ({
 				</div>
 				{!isActiveStream && (
 					<div className="mr-4">
-						<CaretRight className="size-4 text-gray-500" />
+						<CaretRightIcon className="size-4 text-gray-500" />
 					</div>
 				)}
 			</div>

--- a/ui/src/modules/jobs/pages/streams/StreamsCollapsibleList.tsx
+++ b/ui/src/modules/jobs/pages/streams/StreamsCollapsibleList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { CaretDown, CaretRight } from "@phosphor-icons/react"
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react"
 import { Checkbox, Empty } from "antd"
 
 import { GroupedStreamsCollapsibleListProps } from "../../../../types"
@@ -314,12 +314,12 @@ const StreamsCollapsibleList = ({
 									<span className="font-semibold">{ns}</span>
 									<span className="ml-auto">
 										{openNamespaces[ns] ? (
-											<CaretDown
+											<CaretDownIcon
 												className="size-4"
 												weight="fill"
 											/>
 										) : (
-											<CaretRight
+											<CaretRightIcon
 												className="size-4"
 												weight="fill"
 											/>

--- a/ui/src/modules/sources/components/SourceEmptyState.tsx
+++ b/ui/src/modules/sources/components/SourceEmptyState.tsx
@@ -1,5 +1,5 @@
 import { Button } from "antd"
-import { PlayCircle, Plus } from "@phosphor-icons/react"
+import { PlayCircleIcon, PlusIcon } from "@phosphor-icons/react"
 
 import { SourceTutorialYTLink } from "../../../utils/constants"
 import FirstSource from "../../../assets/FirstSource.svg"
@@ -29,7 +29,7 @@ const SourceEmptyState = ({
 				className="border-1 mb-12 border-[1px] border-[#D9D9D9] bg-white px-6 py-4 text-black"
 				onClick={handleCreateSource}
 			>
-				<Plus />
+				<PlusIcon />
 				New Source
 			</Button>
 			<div className="w-[412px] rounded-xl border-[1px] border-[#D9D9D9] bg-white p-4 shadow-sm">
@@ -48,7 +48,7 @@ const SourceEmptyState = ({
 					</a>
 					<div className="flex-1">
 						<div className="mb-1 flex items-center gap-1 text-xs">
-							<PlayCircle color="#9f9f9f" />
+							<PlayCircleIcon color="#9f9f9f" />
 							<span className="text-text-placeholder">OLake/ Tutorial</span>
 						</div>
 						<div className="text-xs">

--- a/ui/src/modules/sources/components/SourceTable.tsx
+++ b/ui/src/modules/sources/components/SourceTable.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react"
 import { Table, Input, Button, Dropdown, Pagination } from "antd"
-import { DotsThree, PencilSimpleLine, Trash } from "@phosphor-icons/react"
+import {
+	DotsThreeIcon,
+	PencilSimpleLineIcon,
+	TrashIcon,
+} from "@phosphor-icons/react"
 
 import { Entity, SourceTableProps } from "../../../types"
 import { getConnectorImage, getConnectorLabel } from "../../../utils/utils"
@@ -45,13 +49,13 @@ const SourceTable: React.FC<SourceTableProps> = ({
 						items: [
 							{
 								key: "edit",
-								icon: <PencilSimpleLine className="size-4" />,
+								icon: <PencilSimpleLineIcon className="size-4" />,
 								label: "Edit",
 								onClick: () => onEdit(record.id.toString()),
 							},
 							{
 								key: "delete",
-								icon: <Trash className="size-4" />,
+								icon: <TrashIcon className="size-4" />,
 								label: "Delete",
 								danger: true,
 								onClick: () => onDelete(record),
@@ -63,7 +67,7 @@ const SourceTable: React.FC<SourceTableProps> = ({
 				>
 					<Button
 						type="text"
-						icon={<DotsThree className="size-5" />}
+						icon={<DotsThreeIcon className="size-5" />}
 					/>
 				</Dropdown>
 			),

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -7,7 +7,12 @@ import {
 } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import { message, Select, Spin } from "antd"
-import { ArrowLeft, ArrowRight, Info, Notebook } from "@phosphor-icons/react"
+import {
+	ArrowLeftIcon,
+	ArrowRightIcon,
+	InfoIcon,
+	NotebookIcon,
+} from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 import validator from "@rjsf/validator-ajv8"
 
@@ -423,7 +428,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 							</>
 						) : (
 							<div className="flex items-center gap-1 text-sm text-red-500">
-								<Info />
+								<InfoIcon />
 								No versions available
 							</div>
 						)}
@@ -531,7 +536,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 								to={"/sources"}
 								className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 							>
-								<ArrowLeft className="mr-1 size-5" />
+								<ArrowLeftIcon className="mr-1 size-5" />
 							</Link>
 							<div className="text-lg font-bold">Create source</div>
 						</div>
@@ -549,7 +554,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 								<div className="mb-6 mt-2 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
 									<div className="mb-6">
 										<div className="mb-4 flex items-center gap-2 text-base font-medium">
-											<Notebook className="size-5" />
+											<NotebookIcon className="size-5" />
 											Capture information
 										</div>
 
@@ -582,7 +587,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 										}}
 									>
 										Create
-										<ArrowRight className="size-4 text-white" />
+										<ArrowRightIcon className="size-4 text-white" />
 									</button>
 								</div>
 							)}

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -4,11 +4,11 @@ import { formatDistanceToNow } from "date-fns"
 import { Input, Button, Select, Switch, message, Table, Spin } from "antd"
 import type { ColumnsType } from "antd/es/table"
 import {
-	GenderNeuter,
-	Notebook,
-	ArrowLeft,
-	PencilSimple,
-	Info,
+	GenderNeuterIcon,
+	NotebookIcon,
+	ArrowLeftIcon,
+	PencilSimpleIcon,
+	InfoIcon,
 } from "@phosphor-icons/react"
 import Form from "@rjsf/antd"
 import validator from "@rjsf/validator-ajv8"
@@ -441,7 +441,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 							to="/sources"
 							className="flex items-center gap-2 p-1.5 hover:rounded-md hover:bg-gray-100 hover:text-black"
 						>
-							<ArrowLeft className="size-5" />
+							<ArrowLeftIcon className="size-5" />
 						</Link>
 						<div className="text-lg font-bold">{sourceName}</div>
 					</div>
@@ -465,7 +465,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 											}
 											className="flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-white hover:bg-primary-600"
 										>
-											<PencilSimple className="size-4" />
+											<PencilSimpleIcon className="size-4" />
 											Edit Source
 										</Link>
 									</div>
@@ -504,7 +504,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 								<div className="bg-white">
 									<div className="mb-6 rounded-xl border border-[#D9D9D9] p-6">
 										<div className="mb-4 flex items-center gap-1 text-lg font-medium">
-											<Notebook className="size-5" />
+											<NotebookIcon className="size-5" />
 											Capture information
 										</div>
 
@@ -574,7 +574,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 													/>
 												) : (
 													<div className="flex items-center gap-1 text-sm text-red-500">
-														<Info />
+														<InfoIcon />
 														No versions available
 													</div>
 												)}
@@ -584,7 +584,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 
 									<div className="mb-6 rounded-xl border border-[#D9D9D9] p-6">
 										<div className="mb-2 flex items-center gap-1">
-											<GenderNeuter className="size-6" />
+											<GenderNeuterIcon className="size-6" />
 											<div className="text-lg font-medium">Endpoint config</div>
 										</div>
 										{loading ? (

--- a/ui/src/modules/sources/pages/Sources.tsx
+++ b/ui/src/modules/sources/pages/Sources.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 import { useNavigate } from "react-router-dom"
 import { Button, Tabs, Empty, message, Spin } from "antd"
-import { LinktreeLogo, Plus } from "@phosphor-icons/react"
+import { LinktreeLogoIcon, PlusIcon } from "@phosphor-icons/react"
 
 import { useAppStore } from "../../../store"
 import analyticsService from "../../../api/services/analyticsService"
@@ -101,14 +101,14 @@ const Sources: React.FC = () => {
 		<div className="p-6">
 			<div className="mb-4 flex items-center justify-between">
 				<div className="flex items-center">
-					<LinktreeLogo className="mr-2 size-6" />
+					<LinktreeLogoIcon className="mr-2 size-6" />
 					<h1 className="text-2xl font-bold">Sources</h1>
 				</div>
 				<button
 					className="flex items-center justify-center gap-1 rounded-md bg-primary px-4 py-2 font-light text-white hover:bg-primary-600"
 					onClick={handleCreateSource}
 				>
-					<Plus className="size-4 text-white" />
+					<PlusIcon className="size-4 text-white" />
 					Create Source
 				</button>
 			</div>

--- a/ui/src/utils/EndpointTitle.tsx
+++ b/ui/src/utils/EndpointTitle.tsx
@@ -1,11 +1,11 @@
-import { GenderNeuter } from "@phosphor-icons/react"
+import { GenderNeuterIcon } from "@phosphor-icons/react"
 
 import { EndpointTitleProps } from "../types"
 
 const EndpointTitle = ({ title = "Endpoint config" }: EndpointTitleProps) => (
 	<div className="mb-4 flex items-center gap-1">
 		<div className="mb-2 flex items-center gap-2">
-			<GenderNeuter className="size-5" />
+			<GenderNeuterIcon className="size-5" />
 			<div className="text-base font-medium">{title}</div>
 		</div>
 	</div>

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,4 +1,8 @@
-import { GitCommit, LinktreeLogo, Path } from "@phosphor-icons/react"
+import {
+	GitCommitIcon,
+	LinktreeLogoIcon,
+	PathIcon,
+} from "@phosphor-icons/react"
 import { JobCreationSteps, NavItem } from "../types"
 import { getResponsivePageSize } from "./utils"
 
@@ -121,9 +125,9 @@ export const LOCALSTORAGE_TOKEN_KEY = "token"
 export const LOCALSTORAGE_USERNAME_KEY = "username"
 
 export const NAV_ITEMS: NavItem[] = [
-	{ path: "/jobs", label: "Jobs", icon: GitCommit },
-	{ path: "/sources", label: "Sources", icon: LinktreeLogo },
-	{ path: "/destinations", label: "Destinations", icon: Path },
+	{ path: "/jobs", label: "Jobs", icon: GitCommitIcon },
+	{ path: "/sources", label: "Sources", icon: LinktreeLogoIcon },
+	{ path: "/destinations", label: "Destinations", icon: PathIcon },
 ]
 
 export const sourceTabs = [

--- a/ui/src/utils/statusIcons.tsx
+++ b/ui/src/utils/statusIcons.tsx
@@ -1,12 +1,16 @@
-import { ArrowsCounterClockwise, Check, XCircle } from "@phosphor-icons/react"
+import {
+	ArrowsCounterClockwiseIcon,
+	CheckIcon,
+	XCircleIcon,
+} from "@phosphor-icons/react"
 
 export const getStatusIcon = (status: string | undefined) => {
 	if (status === "success" || status === "completed") {
-		return <Check className="text-green-500" />
+		return <CheckIcon className="text-green-500" />
 	} else if (status === "failed" || status === "cancelled") {
-		return <XCircle className="text-red-500" />
+		return <XCircleIcon className="text-red-500" />
 	} else if (status === "running") {
-		return <ArrowsCounterClockwise className="text-blue-500" />
+		return <ArrowsCounterClockwiseIcon className="text-blue-500" />
 	}
 	return null
 }


### PR DESCRIPTION
# Description
Updated all deprecated Phosphor icons used in the UI to their latest supported alternatives.
This ensures long-term compatibility, prevents warnings from outdated imports, and aligns the UI with the current Phosphor library updates.
Fixes: #197 
## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
* [x] Verified all replaced icons render correctly in the UI
* [x] Checked for console warnings or import errors

## Related PR's (If Any):
N/A
