### PR TITLE
fix: add cleanup on cancelling fetchSpec API

### DIFF
--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -231,7 +231,7 @@ const CreateDestination = forwardRef<
 				setLoadingVersions(true)
 				try {
 					const response = await destinationService.getDestinationVersions(
-						connector.toLowerCase() === CONNECTOR_TYPES.APACHE_ICEBERG
+						connector === CONNECTOR_TYPES.APACHE_ICEBERG
 							? DESTINATION_INTERNAL_TYPES.ICEBERG
 							: DESTINATION_INTERNAL_TYPES.S3,
 					)
@@ -305,7 +305,7 @@ const CreateDestination = forwardRef<
 		}
 
 		useEffect(() => {
-			handleFetchSpec()
+			return handleFetchSpec()
 		}, [
 			connector,
 			version,

--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -264,7 +264,7 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 	}
 
 	useEffect(() => {
-		handleFetchSpec()
+		return handleFetchSpec()
 	}, [connector, selectedVersion, fromJobFlow, sourceConnector, sourceVersion])
 
 	const handleVersionChange = (value: string) => {

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -225,7 +225,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 		}
 
 		useEffect(() => {
-			handleFetchSpec()
+			return handleFetchSpec()
 		}, [connector, selectedVersion, setupType])
 
 		useEffect(() => {

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -183,7 +183,7 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 	}
 
 	useEffect(() => {
-		handleFetchSpec()
+		return handleFetchSpec()
 	}, [connector, selectedVersion])
 
 	const resetVersionState = () => {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds cleanup on cancelling the fetch spec API to prevent stale states.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
