### PR TITLE
fix: remove redundant api calls from streams section

### DIFF
--- a/ui/src/modules/jobs/pages/JobEdit.tsx
+++ b/ui/src/modules/jobs/pages/JobEdit.tsx
@@ -312,7 +312,7 @@ const JobEdit: React.FC = () => {
 		return null
 	}
 
-	const getjobUpdatePayLoad = (
+	const getJobUpdatePayLoad = (
 		streamsConfig: StreamsDataStructure,
 		diff: StreamsDataStructure | null,
 	) => {
@@ -416,7 +416,7 @@ const JobEdit: React.FC = () => {
 		setIsSubmitting(true)
 		try {
 			// Create the job update payload
-			const jobUpdatePayload = getjobUpdatePayLoad(streamsConfig, diff)
+			const jobUpdatePayload = getJobUpdatePayLoad(streamsConfig, diff)
 
 			await jobService.updateJob(jobId, jobUpdatePayload)
 


### PR DESCRIPTION
# Description

- Remove redundant API calls from the streams section causing weird UI glitches.
- fix bug where in edit streams section, going back to jobs config and then saving caused the resetting of user streams

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested in Job Edit by modifying streams and that change was persisted (which was earlier being overriden by fetch jobs API)
- [x] Tested by going back to jobs config in the Edit Job, and saving... streams were intact and changes were persisted. 

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
