### PR TITLE
fix: disable editing on saved webhook alert url

### DIFF
--- a/ui/src/modules/common/settings/components/AlertsAndNotifications.tsx
+++ b/ui/src/modules/common/settings/components/AlertsAndNotifications.tsx
@@ -2,12 +2,15 @@ import { Button, message } from "antd"
 import { Input } from "antd/lib"
 import { useAppStore } from "../../../../store"
 import { useEffect, useMemo, useState } from "react"
+import { PencilSimpleIcon } from "@phosphor-icons/react"
 
 const AlertsAndNotifications = () => {
 	const { systemSettings, updateWebhookAlertUrl, isUpdatingSystemSettings } =
 		useAppStore()
 
 	const [webhookAlertUrl, setWebhookAlertUrl] = useState<string>("")
+	const [isEditingWebhookAlertUrl, setIsEditingWebhookAlertUrl] =
+		useState<boolean>(false)
 
 	const trimmedWebhookUrl = useMemo(
 		() => webhookAlertUrl.trim(),
@@ -17,12 +20,17 @@ const AlertsAndNotifications = () => {
 	useEffect(() => {
 		if (systemSettings) {
 			setWebhookAlertUrl(systemSettings.webhook_alert_url)
+			// If the webhook alert URL is not set, allow editing
+			setIsEditingWebhookAlertUrl(!systemSettings.webhook_alert_url)
 		}
 	}, [systemSettings])
 
 	const handleWebhookAlertUrlChange = (
 		e: React.ChangeEvent<HTMLInputElement>,
 	) => {
+		if (!isEditingWebhookAlertUrl) {
+			return
+		}
 		setWebhookAlertUrl(e.target.value)
 	}
 
@@ -34,9 +42,21 @@ const AlertsAndNotifications = () => {
 		try {
 			new URL(trimmedWebhookUrl)
 			updateWebhookAlertUrl(trimmedWebhookUrl)
+			setIsEditingWebhookAlertUrl(false)
 		} catch {
 			message.error("Please enter a valid webhook URL")
 		}
+	}
+
+	const handleEnterEditWebhookAlertUrl = () => {
+		setIsEditingWebhookAlertUrl(true)
+	}
+
+	const handleCancelEditWebhookAlertUrl = () => {
+		if (systemSettings) {
+			setWebhookAlertUrl(systemSettings.webhook_alert_url)
+		}
+		setIsEditingWebhookAlertUrl(false)
 	}
 
 	const handleClearWebhookAlertUrl = () => {
@@ -69,26 +89,53 @@ const AlertsAndNotifications = () => {
 								placeholder="Enter your webhook URL"
 								className="h-10 w-96 text-text-secondary"
 								value={webhookAlertUrl}
+								disabled={!isEditingWebhookAlertUrl || isUpdatingSystemSettings}
 								onChange={handleWebhookAlertUrlChange}
 							/>
-							<Button
-								type="default"
-								className="h-10"
-								onClick={handleSaveWebhookAlertUrl}
-								disabled={!trimmedWebhookUrl || isUpdatingSystemSettings}
-							>
-								Save
-							</Button>
-							<Button
-								type="default"
-								className="h-10"
-								onClick={handleClearWebhookAlertUrl}
-								disabled={isUpdatingSystemSettings || !trimmedWebhookUrl}
-								aria-label="Clear webhook URL"
-								title="Clear webhook URL"
-							>
-								Clear
-							</Button>
+							{isEditingWebhookAlertUrl ? (
+								<>
+									<Button
+										type="primary"
+										className="h-10"
+										onClick={handleSaveWebhookAlertUrl}
+										disabled={!trimmedWebhookUrl || isUpdatingSystemSettings}
+									>
+										Save changes
+									</Button>
+									<Button
+										type="default"
+										className="h-10"
+										onClick={handleCancelEditWebhookAlertUrl}
+										disabled={isUpdatingSystemSettings}
+									>
+										Cancel
+									</Button>
+								</>
+							) : (
+								<>
+									<Button
+										type="default"
+										className="h-10"
+										onClick={handleEnterEditWebhookAlertUrl}
+										disabled={isUpdatingSystemSettings}
+									>
+										<span className="flex items-center gap-1">
+											<PencilSimpleIcon className="size-4" />
+											<span>Edit</span>
+										</span>
+									</Button>
+									<Button
+										type="default"
+										className="h-10"
+										onClick={handleClearWebhookAlertUrl}
+										disabled={isUpdatingSystemSettings || !trimmedWebhookUrl}
+										aria-label="Clear webhook URL"
+										title="Clear webhook URL"
+									>
+										Clear
+									</Button>
+								</>
+							)}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
# Description

This PR improves UX of webhook alerts UI by disabling the webhook alert URL field on save and enabling it when user clicks on "Edit" button. It is already on edit mode if Webhook alert URL is empty.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->
<img width="1318" height="942" alt="Screenshot 2025-12-02 at 6 29 10 PM" src="https://github.com/user-attachments/assets/5a84972f-26ed-44c5-bf3f-4afecc1bd309" />

<img width="1322" height="947" alt="Screenshot 2025-12-02 at 6 29 24 PM" src="https://github.com/user-attachments/assets/c0f0e939-e5e0-4304-95a0-51ef346b981d" />

<img width="1323" height="951" alt="Screenshot 2025-12-02 at 6 29 38 PM" src="https://github.com/user-attachments/assets/d7a889c0-c8d8-4b03-84cb-92be523f95c3" />

## Related PR's (If Any):
