### PR TITLE
Improve Job Creation UX with automatic focus management and keyboard shortcut.

### DIFF
--- a/ui/src/modules/common/components/SetupTypeSelector.tsx
+++ b/ui/src/modules/common/components/SetupTypeSelector.tsx
@@ -1,28 +1,40 @@
+import { forwardRef } from "react"
 import { Radio } from "antd"
 import { SetupType, SetupTypeSelectorProps } from "../../../types"
 
-export const SetupTypeSelector: React.FC<SetupTypeSelectorProps> = ({
-	value,
-	onChange,
-	newLabel = "Set up a new source",
-	existingLabel = "Use an existing source",
-	fromJobFlow = false,
-}) => {
-	return (
-		<div className="mb-4 flex">
-			<Radio.Group
-				value={value}
-				onChange={e => onChange(e.target.value as SetupType)}
-				className="flex"
-			>
-				<Radio
-					value="new"
-					className="mr-8"
+export const SetupTypeSelector = forwardRef<
+  any,
+  SetupTypeSelectorProps
+>(
+  (
+    {
+      value,
+      onChange,
+      newLabel = "Set up a new source",
+      existingLabel = "Use an existing source",
+      fromJobFlow = false,
+    },
+    ref,
+  ) => {
+		return (
+			<div className="mb-4 flex">
+				<Radio.Group
+					value={value}
+					onChange={e => onChange(e.target.value as SetupType)}
+					className="flex"
 				>
-					{newLabel}
-				</Radio>
-				{fromJobFlow && <Radio value="existing">{existingLabel}</Radio>}
-			</Radio.Group>
-		</div>
-	)
-}
+					<Radio
+						ref={ref}
+						value="new"
+						className="mr-8"
+					>
+						{newLabel}
+					</Radio>
+					{fromJobFlow && <Radio value="existing">{existingLabel}</Radio>}
+				</Radio.Group>
+			</div>
+		)
+	},
+)
+
+SetupTypeSelector.displayName = "SetupTypeSelector"

--- a/ui/src/modules/jobs/components/JobConfiguration.tsx
+++ b/ui/src/modules/jobs/components/JobConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 import { Input, Select, Radio, Tooltip } from "antd"
 import { InfoIcon } from "@phosphor-icons/react"
 import parser from "cron-parser"
@@ -24,6 +24,7 @@ const JobConfiguration: React.FC<JobConfigurationProps> = ({
 	jobNameFilled = false,
 }) => {
 	const location = useLocation()
+    const jobNameInputRef = useRef<any>(null)
 	const isEditMode = location.pathname.includes("/edit")
 	const [selectedTime, setSelectedTime] = useState("1")
 	const [selectedAmPm, setSelectedAmPm] = useState<"AM" | "PM">("AM")
@@ -100,6 +101,18 @@ const JobConfiguration: React.FC<JobConfigurationProps> = ({
 			updateNextRuns(cronValue)
 		}
 	}, [cronValue])
+	
+	useEffect(() => {
+  		if (
+    		location.pathname === "/jobs/new" &&
+    		!isEditMode &&
+    		!jobNameFilled
+  		) {
+    		requestAnimationFrame(() => {
+      		jobNameInputRef.current?.focus()
+    		})
+  		}
+	}, [location.pathname, isEditMode, jobNameFilled])
 
 	// Unified handler for all cron expression updates
 	const updateCronExpression = (
@@ -181,6 +194,7 @@ const JobConfiguration: React.FC<JobConfigurationProps> = ({
 							Job name:<span className="text-red-500">*</span>
 						</label>
 						<Input
+							ref={jobNameInputRef}
 							value={jobName}
 							disabled={isEditMode || jobNameFilled}
 							onChange={e => {

--- a/ui/src/modules/jobs/pages/JobCreation.tsx
+++ b/ui/src/modules/jobs/pages/JobCreation.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect } from "react"
 import { useNavigate, Link, useLocation } from "react-router-dom"
-import { message } from "antd"
+import { message, Tooltip } from "antd"
 import {
 	ArrowLeftIcon,
 	ArrowRightIcon,
@@ -334,6 +334,21 @@ const JobCreation: React.FC = () => {
 
 	//TODO: Handle steps properly
 
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			const isMac = navigator.platform.toUpperCase().includes("MAC")
+			const modifierPressed = isMac ? e.metaKey : e.ctrlKey
+
+			if ( modifierPressed && e.key === "Enter" && !( currentStep === JOB_CREATION_STEPS.STREAMS && isStreamsLoading )) {
+				e.preventDefault()
+				handleNext()
+			}
+		}
+
+		window.addEventListener("keydown", handler)
+		return () => window.removeEventListener("keydown", handler)
+	}, [handleNext, currentStep, isStreamsLoading])
+
 	const handleConfirmResetStreams = () => {
 		setSelectedStreams([])
 		setCurrentStep(JOB_CREATION_STEPS.DESTINATION)
@@ -563,13 +578,29 @@ const JobCreation: React.FC = () => {
 							Back
 						</button>
 					)}
-					<button
-						className="flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-1 font-light text-white hover:bg-primary-600"
-						onClick={handleNext}
+					<Tooltip
+						title={
+							<div className="flex items-center gap-1">
+								<span className="rounded border border-gray-300 bg-white px-1.5 py-0.5 text-[11px] font-medium text-black shadow-sm">
+									Ctrl
+								</span>
+								<span className="text-xs">+</span>
+								<span className="rounded border border-gray-300 bg-white px-1.5 py-0.5 text-[11px] font-medium text-black shadow-sm">
+									Enter
+								</span>
+							</div>
+						}
+						placement="top"
 					>
-						{currentStep === JOB_CREATION_STEPS.STREAMS ? "Create Job" : "Next"}
-						<ArrowRightIcon className="size-4 text-white" />
-					</button>
+						<button
+							className="flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-1 font-light text-white hover:bg-primary-600"
+							onClick={handleNext}
+							aria-keyshortcuts="Control+Enter"
+						>
+							{currentStep === JOB_CREATION_STEPS.STREAMS ? "Create Job" : "Next"}
+							<ArrowRightIcon className="size-4 text-white" />
+						</button>
+					</Tooltip>
 					<TestConnectionModal />
 					<TestConnectionSuccessModal />
 					<EntitySavedModal

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -80,6 +80,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 		ref,
 	) => {
 		const formRef = useRef<any>(null)
+		const setupTypeRef = useRef<any>(null)
 		const [setupType, setSetupType] = useState<SetupType>("new")
 		const [connector, setConnector] = useState(initialConnector || "MongoDB")
 		const [sourceName, setSourceName] = useState(initialName || "")
@@ -137,6 +138,13 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 				)
 			}
 		}, [connector, setupType, fetchSources])
+
+		useEffect(() => {
+	  		requestAnimationFrame(() => {
+    			setupTypeRef.current?.focus()
+  			})
+		}, [])
+
 
 		const resetVersionState = () => {
 			setVersions([])
@@ -554,6 +562,7 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 
 		const renderSetupTypeSelector = () => (
 			<SetupTypeSelector
+				ref={setupTypeRef}
 				value={setupType as SetupType}
 				onChange={handleSetupTypeChange}
 				newLabel="Set up a new source"


### PR DESCRIPTION
# Description

**Summary**
This PR improves the Job Creation user experience by enhancing keyboard accessibility and focus management across steps.
1. Added Ctrl + Enter keyboard shortcut to proceed to the next step or create the job along with a tooltip for discoverability.
2. Added automatic focus management to reduce unnecessary clicks by guiding focus to the most relevant control in each step.

**Motivation and Context**
The Job Creation flow is a multi-step, form-heavy experience. Requiring mouse interaction for each step adds friction, especially for power users and keyboard-first workflows.

These changes aim to:
Reduce unnecessary clicks by guiding focus to the most relevant control in each step.
Enable faster navigation using a familiar and non-intrusive keyboard shortcut.


## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Screenshots or Recordings
[Screencast from 2025-12-19 23-52-11.webm](https://github.com/user-attachments/assets/f5be0b41-f901-4dff-a831-f52560d2421b)
The video shows automatic focus on the first input to improve tab navigation and enable faster navigation, along with a keyboard shortcut to move to the next step.
The cursor is not visible in the screencast, apologies for that.

