### PR TITLE
fix: prevent auto-selecting latest version on source edit page

### DIFF
--- a/ui/src/modules/destinations/pages/DestinationEdit.tsx
+++ b/ui/src/modules/destinations/pages/DestinationEdit.tsx
@@ -217,14 +217,6 @@ const DestinationEdit: React.FC<DestinationEditProps> = ({
 
 				if (response?.version) {
 					setVersions(response.version)
-
-					// If no version is selected, set the first one as default
-					if (!selectedVersion && response.version.length > 0) {
-						setSelectedVersion(response.version[0])
-						if (onVersionChange) {
-							onVersionChange(response.version[0])
-						}
-					}
 				} else {
 					resetVersionState()
 				}

--- a/ui/src/modules/sources/pages/SourceEdit.tsx
+++ b/ui/src/modules/sources/pages/SourceEdit.tsx
@@ -218,26 +218,6 @@ const SourceEdit: React.FC<SourceEditProps> = ({
 						value: version,
 					}))
 					setAvailableVersions([...versions])
-					if (
-						source?.type !== normalizedSourceConnector &&
-						versions.length > 0 &&
-						!initialData
-					) {
-						setSelectedVersion(versions[0].value)
-						if (onVersionChange) {
-							onVersionChange(versions[0].value)
-						}
-					} else if (initialData) {
-						if (
-							initialData?.type != normalizedSourceConnector &&
-							initialData.version
-						) {
-							setSelectedVersion(initialData.version)
-							if (onVersionChange) {
-								onVersionChange(initialData.version)
-							}
-						}
-					}
 				} else {
 					resetVersionState()
 				}


### PR DESCRIPTION
# Description

This PR fixes a bug where navigating to the Source "Edit" page would incorrectly display the latest available version instead of the actual configured version.

The issue was caused by a race condition in the useEffect hook responsible for fetching available versions. During client-side navigation, the effect would sometimes run before the source data was fully loaded (stale state), causing the "auto-select version" logic to trigger wrongly and overwrite the correct version.

Since the connector type is locked in Edit mode, the auto-select logic was unnecessary. This fix simply removes that logic from `SourceEdit.tsx`and `DestinationEdit.tsx`, ensuring the saved version is always respected.

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Scenario A: Verified that navigating from the Sources/Destinations list to the Edit page correctly preserves and displays the saved version (e.g., v0.3.13) instead of defaulting to the latest.
- [x] Scenario B: Verified that refreshing the Edit page continues to display the correct version.
- [x] Scnario C: Verified that in Job Edit page versions of Source/Destinations are correctly displayed 

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
