### PR TITLE
fix: fallback version in air-gapped environments

### DIFF
--- a/server/internal/services/etl/destination.go
+++ b/server/internal/services/etl/destination.go
@@ -10,6 +10,7 @@ import (
 	"github.com/datazip-inc/olake-ui/server/internal/models"
 	"github.com/datazip-inc/olake-ui/server/internal/models/dto"
 	"github.com/datazip-inc/olake-ui/server/utils"
+	"github.com/datazip-inc/olake-ui/server/utils/logger"
 	"github.com/datazip-inc/olake-ui/server/utils/telemetry"
 )
 
@@ -247,7 +248,8 @@ func (s *ETLService) GetDestinationVersions(ctx context.Context, destType string
 
 	versions, _, err := utils.GetDriverImageTags(ctx, "", true)
 	if err != nil {
-		return dto.VersionsResponse{}, fmt.Errorf("failed to get driver image tags: %s", err)
+		logger.Warnf("failed to get driver image tags (air-gapped?): %s — returning fallback", err)
+		return dto.VersionsResponse{Version: []string{constants.DefaultSpecVersion}}, nil
 	}
 
 	return dto.VersionsResponse{Version: versions}, nil

--- a/server/internal/services/etl/source.go
+++ b/server/internal/services/etl/source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/datazip-inc/olake-ui/server/internal/models"
 	"github.com/datazip-inc/olake-ui/server/internal/models/dto"
 	"github.com/datazip-inc/olake-ui/server/utils"
+	"github.com/datazip-inc/olake-ui/server/utils/logger"
 	"github.com/datazip-inc/olake-ui/server/utils/telemetry"
 )
 
@@ -271,7 +272,8 @@ func (s *ETLService) GetSourceVersions(ctx context.Context, sourceType string) (
 	imageName := fmt.Sprintf("olakego/source-%s", sourceType)
 	versions, _, err := utils.GetDriverImageTags(ctx, imageName, true)
 	if err != nil {
-		return dto.VersionsResponse{}, fmt.Errorf("failed to get Docker versions: %s", err)
+		logger.Warnf("failed to get Docker versions for %s (air-gapped?): %s — returning fallback", sourceType, err)
+		return dto.VersionsResponse{Version: []string{constants.DefaultSpecVersion}}, nil
 	}
 
 	return dto.VersionsResponse{Version: versions}, nil

--- a/ui/src/modules/destinations/pages/CreateDestination.tsx
+++ b/ui/src/modules/destinations/pages/CreateDestination.tsx
@@ -279,8 +279,15 @@ const CreateDestination = forwardRef<
 						resetVersionState()
 					}
 				} catch (error) {
-					resetVersionState()
-					console.error("Error fetching versions:", error)
+					// Fallback: use initialVersion or "latest" so users can proceed
+					// in air-gapped environments where version fetch fails (#340)
+					const fallback = initialVersion || "v0.2.0"
+					setVersions([fallback])
+					setVersion(fallback)
+					if (onVersionChange) {
+						onVersionChange(fallback)
+					}
+					console.warn("Version fetch failed (air-gapped?), using fallback:", fallback)
 				} finally {
 					setLoadingVersions(false)
 				}

--- a/ui/src/modules/sources/pages/CreateSource.tsx
+++ b/ui/src/modules/sources/pages/CreateSource.tsx
@@ -205,8 +205,15 @@ const CreateSource = forwardRef<CreateSourceHandle, CreateSourceProps>(
 						resetVersionState()
 					}
 				} catch (error) {
-					resetVersionState()
-					console.error("Error fetching versions:", error)
+					// Fallback: use initialVersion or "latest" so users can proceed
+					// in air-gapped environments where version fetch fails (#340)
+					const fallback = initialVersion || "v0.2.0"
+					setVersions([fallback])
+					setSelectedVersion(fallback)
+					if (onVersionChange) {
+						onVersionChange(fallback)
+					}
+					console.warn("Version fetch failed (air-gapped?), using fallback:", fallback)
 				} finally {
 					setLoadingVersions(false)
 				}


### PR DESCRIPTION
## Problem

Source and destination creation is **completely blocked** in air-gapped / private-network deployments because the version dropdown stays empty when Docker Hub / GitHub is unreachable.

**Root cause:** `GetSourceVersions` and `GetDestinationVersions` return hard errors when `GetDriverImageTags` fails, and the frontend's `validateSource()` rejects empty versions with `"No versions available"`.

Fixes #340

## Changes

### Server (`server/internal/services/etl/`)

- **`source.go`** — `GetSourceVersions`: return `DefaultSpecVersion` as fallback instead of error
- **`destination.go`** — `GetDestinationVersions`: same fallback behavior
- Both log a warning so operators can see it in logs

### Frontend (`ui/src/modules/`)

- **`CreateSource.tsx`** — catch block uses `initialVersion || "v0.2.0"` fallback instead of `resetVersionState()`
- **`CreateDestination.tsx`** — same fallback

## Behavior

| Environment | Before | After |
|-------------|--------|-------|
| Internet available | ✅ Fetches versions from Docker Hub | ✅ Same (no change) |
| Air-gapped | ❌ Empty dropdown, Next blocked | ✅ Falls back to default version |
| BFF updated, frontend not | ❌ 500 error | ✅ Frontend fallback kicks in |
| Frontend updated, BFF not | ❌ Empty dropdown | ✅ Server fallback kicks in |

Double-layer defense: even if only one side is updated, the fix works.

## Testing

- Verified version fetch failure path returns fallback version
- Verified `validateSource()` accepts fallback version and proceeds to next step
- No changes to existing happy-path behavior