### PR TITLE
fix: auto-detect RUN_MODE based on execution environment (docker/k8s)

### DIFF
--- a/server/conf/app.yaml
+++ b/server/conf/app.yaml
@@ -1,6 +1,8 @@
 APP_NAME: olake-server
 HTTP_PORT: "8000"
-RUN_MODE: dev
+# RUN_MODE is auto-detected: "dev" for Docker, "staging" for Kubernetes (via KUBERNETES_SERVICE_HOST).
+# Override explicitly via RUN_MODE env var or uncomment below if needed.
+# RUN_MODE: dev
 
 MAX_MEMORY: 67108864
 MAX_UPLOAD_SIZE: 67108864

--- a/server/internal/appconfig/appconfig.go
+++ b/server/internal/appconfig/appconfig.go
@@ -1,6 +1,7 @@
 package appconfig
 
 import (
+	"os"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -39,6 +40,15 @@ func Load() Config {
 
 func loadConfig() Config {
 	v := viper.New()
+
+	// Auto-detect RUN_MODE default based on execution environment.
+	// KUBERNETES_SERVICE_HOST is automatically injected into every pod by Kubernetes.
+	// Priority: RUN_MODE env var > app.yaml > this default.
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		v.SetDefault("RUN_MODE", "staging")
+	} else {
+		v.SetDefault("RUN_MODE", "dev")
+	}
 
 	// Note: config priority: env variables -> file (app.yaml)
 	v.SetConfigFile("./config/app.yaml")


### PR DESCRIPTION
# Description

After the beego → gin migration, `RUN_MODE` was hardcoded to `dev` in `app.yaml`. This caused all deployments to query `olake-dev-*` tables regardless of environment, breaking login for Kubernetes/Helm users whose data lives in `olake-staging-*` tables.

## Behaviour
| Environment     | Effective RUN_MODE   |
|-----------------|----------------------|
| Docker Compose  | `dev`  (auto)        |
| Kubernetes/Helm | `staging` (auto)     |
| Any + override  | value of `RUN_MODE` env var |

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
