### PR TITLE
fix: resolve database migration failures when upgrading from <= 0.4.1

### DIFF
--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -9,6 +9,7 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/datazip-inc/olake-ui/server/internal/appconfig"
+	"github.com/datazip-inc/olake-ui/server/internal/constants"
 	"github.com/datazip-inc/olake-ui/server/internal/models"
 	"github.com/datazip-inc/olake-ui/server/internal/utils/logger"
 )
@@ -31,20 +32,28 @@ func Init() (*Database, error) {
 	}
 
 	conn, err := gorm.Open(postgres.Open(uri), &gorm.Config{
-		Logger: gormlogger.Default.LogMode(logLevel),
+		Logger:                                   gormlogger.Default.LogMode(logLevel),
+		DisableForeignKeyConstraintWhenMigrating: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to postgres: %s", err)
 	}
 
-	// migration for database tables
+	// Clean up constraints left by beego-orm and early GORM versions before
+	// AutoMigrate runs, so upgrades from <= 0.4.1 don't fail on duplicates.
+	if err := dropLegacyConstraints(conn); err != nil {
+		return nil, fmt.Errorf("failed to drop legacy constraints: %s", err)
+	}
+
+	// Order matters for fresh installs: tables with no FK dependencies first,
+	// then tables that reference them. Source/Destination/Job all FK → User.
 	if err := conn.AutoMigrate(
+		new(models.User),
 		new(models.ProjectSettings),
+		new(models.Catalog),
 		new(models.Source),
 		new(models.Destination),
 		new(models.Job),
-		new(models.User),
-		new(models.Catalog),
 	); err != nil {
 		return nil, fmt.Errorf("failed to run automigrate: %s", err)
 	}
@@ -65,6 +74,60 @@ func Init() (*Database, error) {
 		}
 	}
 	return &Database{conn: conn}, nil
+}
+
+// dropLegacyConstraints cleans up constraints left behind by previous ORM versions
+// (beego-orm and early GORM) that conflict with the current GORM AutoMigrate:
+//
+//   - "uni_*" unique constraints (GORM `unique` tag, non-idempotent) → replaced by `uniqueIndex`
+//   - "*_fkey" foreign key constraints (beego-orm naming) → GORM recreates with "fk_*" names,
+//     causing duplicate constraints that are harmless but add clutter.
+//
+// All DROP statements use IF EXISTS so this is a no-op on fresh installs.
+func dropLegacyConstraints(conn *gorm.DB) error {
+	userTable := constants.TableNameMap[constants.UserTable]
+	projectSettingsTable := constants.TableNameMap[constants.ProjectSettingsTable]
+	sourceTable := constants.TableNameMap[constants.SourceTable]
+	destTable := constants.TableNameMap[constants.DestinationTable]
+	jobTable := constants.TableNameMap[constants.JobTable]
+
+	constraints := []struct {
+		table      string
+		constraint string
+	}{
+		// Legacy GORM unique constraints (non-idempotent `unique` tag → now `uniqueIndex`)
+		{projectSettingsTable, fmt.Sprintf("uni_%s_project_id", projectSettingsTable)},
+		{userTable, fmt.Sprintf("uni_%s_username", userTable)},
+		{userTable, fmt.Sprintf("uni_%s_email", userTable)},
+
+		// Legacy beego-orm unique constraints (PostgreSQL default naming: <table>_<column>_key)
+		{projectSettingsTable, fmt.Sprintf("%s_project_id_key", projectSettingsTable)},
+		{userTable, fmt.Sprintf("%s_username_key", userTable)},
+		{userTable, fmt.Sprintf("%s_email_key", userTable)},
+
+		// GORM FK constraints (fk_<table>_<assoc> naming). FK creation is now disabled
+		// via DisableForeignKeyConstraintWhenMigrating because GORM's HasConstraint
+		// queries information_schema, which filters by table ownership — if the DB
+		// user doesn't own the tables (common with external RDS), GORM can't see
+		// existing FK constraints and tries to recreate them, causing "already exists"
+		// errors. The app enforces referential integrity in code.
+		{sourceTable, fmt.Sprintf("fk_%s_created_by", sourceTable)},
+		{sourceTable, fmt.Sprintf("fk_%s_updated_by", sourceTable)},
+		{destTable, fmt.Sprintf("fk_%s_created_by", destTable)},
+		{destTable, fmt.Sprintf("fk_%s_updated_by", destTable)},
+		{jobTable, fmt.Sprintf("fk_%s_source", jobTable)},
+		{jobTable, fmt.Sprintf("fk_%s_destination", jobTable)},
+		{jobTable, fmt.Sprintf("fk_%s_created_by", jobTable)},
+		{jobTable, fmt.Sprintf("fk_%s_updated_by", jobTable)},
+	}
+
+	for _, c := range constraints {
+		sql := fmt.Sprintf(`ALTER TABLE IF EXISTS %q DROP CONSTRAINT IF EXISTS %q`, c.table, c.constraint)
+		if err := conn.Exec(sql).Error; err != nil {
+			return fmt.Errorf("failed to drop constraint %s on %s: %w", c.constraint, c.table, err)
+		}
+	}
+	return nil
 }
 
 // BuildPostgresURIFromConfig reads POSTGRES_DB_HOST, POSTGRES_DB_PORT, etc. from app.conf

--- a/server/internal/models/db.go
+++ b/server/internal/models/db.go
@@ -17,9 +17,9 @@ type BaseModel struct {
 type User struct {
 	BaseModel
 	ID       int    `json:"id" gorm:"column:id;primaryKey;autoIncrement"`
-	Username string `json:"username" gorm:"column:username;size:100;unique"`
+	Username string `json:"username" gorm:"column:username;size:100;uniqueIndex"`
 	Password string `json:"password" gorm:"column:password;size:100"`
-	Email    string `json:"email" gorm:"column:email;size:100;unique"`
+	Email    string `json:"email" gorm:"column:email;size:100;uniqueIndex"`
 }
 
 func (u *User) TableName() string {
@@ -30,7 +30,7 @@ func (u *User) TableName() string {
 type ProjectSettings struct {
 	BaseModel
 	ID              int    `json:"id" gorm:"column:id;primaryKey;autoIncrement"`
-	ProjectID       string `json:"project_id" gorm:"column:project_id;size:255;unique"`
+	ProjectID       string `json:"project_id" gorm:"column:project_id;size:255;uniqueIndex"`
 	WebhookAlertURL string `json:"webhook_alert_url" gorm:"column:webhook_alert_url;size:512"`
 }
 


### PR DESCRIPTION
## Summary

Fixes database startup failures when upgrading from v0.4.1 (or earlier) to v0.4.3, specifically affecting users with **external PostgreSQL databases** (e.g., AWS RDS) where the connecting role does not own the tables.

**Reported error:**
```
ERROR: relation "uni_olake-staging-project-settings_project_id" already exists (SQLSTATE 42P07)
FTL Failed to initialize database: failed to run automigrate
```

## Root Cause

The beego-to-gin migration (#335) switched from beego-orm to GORM. GORM's `AutoMigrate` relies on `information_schema` views (`table_constraints`, `constraint_column_usage`) to detect existing constraints before creating them. However, **PostgreSQL's `information_schema` filters results by table ownership** — if the connecting DB role doesn't own the tables, these views return 0 rows even though the constraints exist.

This is exactly what happened to the affected user:
- The `olake-staging-*` tables were originally created by the `postgres` role (during v0.4.1 / beego era)
- The helm chart connects as `olake_admin` (a different role)
- `olake_admin` can execute `ALTER TABLE` on these tables (has sufficient RDS privileges), but `information_schema` returns nothing because it's not the owner:

```sql
-- As olake_admin: sees NOTHING for olake-staging tables
SELECT * FROM information_schema.constraint_column_usage WHERE table_name LIKE 'olake-staging%';
→ (0 rows)

-- As postgres (owner): sees everything
SELECT * FROM information_schema.constraint_column_usage WHERE table_name LIKE 'olake-staging%';
→ (20 rows)
```

This caused GORM to think constraints didn't exist and blindly fire `ALTER TABLE ADD CONSTRAINT` — which failed because the constraints **do** exist at the PostgreSQL engine level.

**Why internal testing didn't catch this:** Our docker-compose setup uses a single `temporal` user that both creates and connects to the tables, so there's no ownership mismatch. The bug only surfaces when the table owner differs from the connecting role — common in external RDS setups where tables were created by one role and the app connects as another.

## Changes

### 1. `unique` → `uniqueIndex` on three model fields (`server/internal/models/db.go`)

**Affected fields:** `User.Username`, `User.Email`, `ProjectSettings.ProjectID`

GORM's `unique` tag triggers two problematic code paths:
- `MigrateColumnUnique`: queries `information_schema.table_constraints` to check if column is unique → fails due to ownership filter → tries `ALTER TABLE ADD CONSTRAINT` → "already exists"
- `HasConstraint`: same `information_schema` query, same failure

Changed to `uniqueIndex`, which takes a completely different code path:
- Does NOT go through `MigrateColumnUnique` (because `field.Unique = false`)
- Goes through the index loop → `HasIndex` queries `pg_indexes` (**not** ownership-filtered) → `CreateIndex` generates `CREATE UNIQUE INDEX IF NOT EXISTS` (SQL-level idempotent)

Same database-level uniqueness guarantee, but immune to the `information_schema` ownership issue.

### 2. `DisableForeignKeyConstraintWhenMigrating: true` (`server/internal/database/database.go`)

GORM's FK constraint loop in `AutoMigrate` uses `HasConstraint` → same `information_schema.table_constraints` query → same ownership filter failure. Without this fix, after resolving the unique constraint error, the **FK constraints would become the next blocker**:

```
ERROR: constraint "fk_olake-staging-source_created_by" already exists
```

This wasn't surfacing before because the unique constraint error terminated `AutoMigrate` before reaching the FK loop. Our `uniqueIndex` fix unblocks `AutoMigrate` to proceed further, exposing this latent issue.

Setting `DisableForeignKeyConstraintWhenMigrating: true` skips FK constraint creation/detection during migration entirely. The app already enforces referential integrity in code (e.g., `DeleteSource` checks for associated jobs before allowing deletion).

### 3. Reorder `AutoMigrate` models (`server/internal/database/database.go`)

**Before:** `ProjectSettings, Source, Destination, Job, User, Catalog`
**After:** `User, ProjectSettings, Catalog, Source, Destination, Job`

`Source`, `Destination`, and `Job` all have FK references to `User`. On a **fresh install**, GORM creates tables sequentially with inline FK constraints — creating `Source` before `User` exists would fail. This only affects fresh installs (on upgrades all tables already exist).

### 4. `dropLegacyConstraints()` pre-migration cleanup (`server/internal/database/database.go`)

Runs before `AutoMigrate` using raw SQL (`ALTER TABLE IF EXISTS ... DROP CONSTRAINT IF EXISTS`) which operates at the engine level and is **not affected by `information_schema` ownership filtering**.

Drops three categories of legacy constraints:

| Constraint pattern | Source | Why drop it |
|---|---|---|
| `uni_<table>_<column>` | GORM `unique` tag (v0.4.3) | Non-idempotent, replaced by `uniqueIndex` |
| `<table>_<column>_key` | beego-orm (v0.4.1) | Stale duplicate from previous ORM |
| `fk_<table>_<assoc>` | GORM FK (v0.4.3) | FK creation now disabled; clean up existing ones |

All use `IF EXISTS` — complete no-op on fresh installs.

## GORM `information_schema` ownership analysis

| AutoMigrate operation | `information_schema` view used | Ownership-filtered? | Our fix |
|---|---|---|---|
| `HasTable` | `tables` | No (shows accessible tables) | N/A |
| `ColumnTypes` (columns) | `columns` | No (shows accessible columns) | N/A |
| `ColumnTypes` (unique detect) | `table_constraints` + `constraint_column_usage` | **Yes** | `uniqueIndex` bypasses this |
| `MigrateColumnUnique` | Uses result from above | **Yes** | `uniqueIndex` → `field.Unique=false` → no-op |
| FK constraint loop | `HasConstraint` → `table_constraints` | **Yes** | `DisableForeignKeyConstraintWhenMigrating` |
| Index loop | `HasIndex` → `pg_indexes` | No | N/A |

## Scenarios covered

| Scenario | Before this PR | After this PR |
|---|---|---|
| External RDS, table owner ≠ connecting role | **Fatal:** `information_schema` invisible → "already exists" | Works: bypasses `information_schema` entirely |
| Upgrade from v0.4.1 → latest | **Fatal:** `SQLSTATE 42P07` on `uni_*` constraint | Works: old constraints dropped, idempotent indexes created |
| Restart (same version) | **Fatal on external RDS:** same `42P07` on every restart | Works: `uniqueIndex` is idempotent, FK loop skipped |
| Fresh install (new database) | **Potentially fatal:** FK to User table fails if User not created yet | Works: correct model ordering |
| Existing sessions after upgrade | Users logged out (beego gob → gin JSON serialization) | Same — expected behavior, handled gracefully |

## Test plan

- [ ] Upgrade from v0.4.1 database to this version — server starts without errors
- [ ] Fresh install with empty database — all tables and constraints created correctly
- [ ] Restart the server multiple times — no migration errors on subsequent startups
- [ ] Verify unique constraints work: duplicate `project_id` / `username` / `email` are rejected
- [ ] Test with external PostgreSQL where connecting role ≠ table owner
- [ ] Verify source/destination deletion checks still enforce referential integrity (cannot delete source with associated jobs)