### PR TITLE
fix: propagate shared env to fusion optimizer Spark pods for IMDS

### DIFF
--- a/docker-compose-v1.yml
+++ b/docker-compose-v1.yml
@@ -190,7 +190,6 @@ services:
       PGPASSWORD: temporal
     volumes:
       - fusion-config:/fusion-config
-      # - ./optimization:/local-optimization:ro
     entrypoint:
       - /bin/sh
       - -c
@@ -213,7 +212,7 @@ services:
                 v = ENVIRON[k]
                 gsub(/"/, "\\\"", v)
                 env_lines = env_lines sprintf("      spark-conf.spark.kubernetes.driverEnv.%s: \"%s\"\n", k, v)
-                env_lines = env_lines sprintf("      spark-conf.spark.kubernetes.executorEnv.%s: \"%s\"\n", k, v)
+                env_lines = env_lines sprintf("      spark-conf.spark.executorEnv.%s: \"%s\"\n", k, v)
               }
             }
             /SPARK_POD_ENVS_PLACEHOLDER/ { printf "%s", env_lines; next }
@@ -230,12 +229,6 @@ services:
         curl -fsSL "$${BASE}/kind-config.yaml" -o /fusion-config/kind-config.yaml
         curl -fsSL "$${BASE}/spark-rbac.yaml"  -o /fusion-config/spark-rbac.yaml
         inject_pod_envs /tmp/config.yaml /fusion-config/config.yaml
-
-        # TODO: remove kept for local testing
-        # echo "==> Copying local Fusion config files..."
-        # inject_pod_envs /local-optimization/config.yaml /fusion-config/config.yaml
-        # cp /local-optimization/kind-config.yaml /fusion-config/kind-config.yaml
-        # cp /local-optimization/spark-rbac.yaml  /fusion-config/spark-rbac.yaml
 
         echo "==> fusion-db-init complete."
     restart: "no"
@@ -366,7 +359,6 @@ services:
     networks:
       - olake-network
     environment:
-      <<: *sharedEnvs
       AMORO_LOG_DIR: *amoroLogPersistencePath
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose-v1.yml
+++ b/docker-compose-v1.yml
@@ -186,9 +186,11 @@ services:
     networks:
       - olake-network
     environment:
+      <<: *sharedEnvs
       PGPASSWORD: temporal
     volumes:
       - fusion-config:/fusion-config
+      # - ./optimization:/local-optimization:ro
     entrypoint:
       - /bin/sh
       - -c
@@ -202,14 +204,38 @@ services:
           || psql -h postgresql -U temporal -c \
              "CREATE DATABASE fusion;"
 
+        inject_pod_envs() {
+          src="$1"
+          dst="$2"
+          awk '
+            BEGIN {
+              for (k in ENVIRON) {
+                v = ENVIRON[k]
+                gsub(/"/, "\\\"", v)
+                env_lines = env_lines sprintf("      spark-conf.spark.kubernetes.driverEnv.%s: \"%s\"\n", k, v)
+                env_lines = env_lines sprintf("      spark-conf.spark.kubernetes.executorEnv.%s: \"%s\"\n", k, v)
+              }
+            }
+            /SPARK_POD_ENVS_PLACEHOLDER/ { printf "%s", env_lines; next }
+            { print }
+          ' "$$src" > "$$dst"
+        }
+
         echo "==> Installing curl..."
         apt-get update -qq && apt-get install -y -qq curl ca-certificates --no-install-recommends >/dev/null 2>&1
 
         echo "==> Fetching Fusion config files from GitHub..."
         BASE="https://raw.githubusercontent.com/datazip-inc/olake-ui/master/optimization"
-        curl -fsSL "$${BASE}/config.yaml"      -o /fusion-config/config.yaml
+        curl -fsSL "$${BASE}/config.yaml"      -o /tmp/config.yaml
         curl -fsSL "$${BASE}/kind-config.yaml" -o /fusion-config/kind-config.yaml
         curl -fsSL "$${BASE}/spark-rbac.yaml"  -o /fusion-config/spark-rbac.yaml
+        inject_pod_envs /tmp/config.yaml /fusion-config/config.yaml
+
+        # TODO: remove kept for local testing
+        # echo "==> Copying local Fusion config files..."
+        # inject_pod_envs /local-optimization/config.yaml /fusion-config/config.yaml
+        # cp /local-optimization/kind-config.yaml /fusion-config/kind-config.yaml
+        # cp /local-optimization/spark-rbac.yaml  /fusion-config/spark-rbac.yaml
 
         echo "==> fusion-db-init complete."
     restart: "no"
@@ -340,6 +366,7 @@ services:
     networks:
       - olake-network
     environment:
+      <<: *sharedEnvs
       AMORO_LOG_DIR: *amoroLogPersistencePath
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/optimization/config.yaml
+++ b/optimization/config.yaml
@@ -129,6 +129,7 @@ containers:
       spark-conf.spark.kubernetes.namespace: spark
       spark-conf.spark.kubernetes.authenticate.driver.serviceAccountName: spark
       spark-conf.spark.kubernetes.authenticate.executor.serviceAccountName: spark
+      SPARK_POD_ENVS_PLACEHOLDER
       spark-conf.spark.dynamicAllocation.enabled: "true"
       spark-conf.spark.shuffle.service.enabled: "false"
       spark-conf.spark.dynamicAllocation.shuffleTracking.enabled: "true"

--- a/optimization/config.yaml
+++ b/optimization/config.yaml
@@ -129,7 +129,6 @@ containers:
       spark-conf.spark.kubernetes.namespace: spark
       spark-conf.spark.kubernetes.authenticate.driver.serviceAccountName: spark
       spark-conf.spark.kubernetes.authenticate.executor.serviceAccountName: spark
-      SPARK_POD_ENVS_PLACEHOLDER
       spark-conf.spark.dynamicAllocation.enabled: "true"
       spark-conf.spark.shuffle.service.enabled: "false"
       spark-conf.spark.dynamicAllocation.shuffleTracking.enabled: "true"
@@ -152,3 +151,5 @@ containers:
       # Force Log4j2 to use the routing config (belt-and-suspenders with the Dockerfile COPY)
       spark-conf.spark.driver.extraJavaOptions: "-Dlog4j2.configurationFile=file:///opt/spark/conf/log4j2.xml"
       spark-conf.spark.executor.extraJavaOptions: "-Dlog4j2.configurationFile=file:///opt/spark/conf/log4j2.xml"
+      # Placeholder for environment variables to be injected into Spark driver/executor pods, e.g. for credentials
+      SPARK_POD_ENVS_PLACEHOLDER


### PR DESCRIPTION
# Description

Fix Fusion Spark optimizer pod AWS/IMDS env propagation by wiring shared compose envs into generated optimizer Spark config.

### What changed

- Updated `docker-compose-v1.yml`:
  - ensured shared env values are available during Fusion config generation
  - updated `fusion-db-init` config rendering flow to inject envs into Spark driver/executor settings
- Updated `optimization/config.yaml`:
  - added placeholder-based env insertion point used during config rendering

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Scenario A: Baseline deploy (without fix) where optimizer pod did not pick required AWS env for IMDS flow.
- [x] Scenario B: Deploy with fix; verified optimizer pod receives env and can run IMDSv2 token -> role -> credentials flow.

# Screenshots or Recordings

N/A (validated via terminal and in-pod commands)

## Related PR's (If Any):

N/A