### PR TITLE
feat(server): add CONNECTOR_DISCOVERY_ENABLED flag to disable registry polling

### DIFF
--- a/server/conf/app.yaml
+++ b/server/conf/app.yaml
@@ -27,6 +27,16 @@ SESSION_ON: true
 TEMPORAL_ADDRESS: temporal:7233
 CONTAINER_REGISTRY_BASE: registry-1.docker.io
 
+# Set to false in Fusion-only or air-gapped deployments to disable upstream
+# container registry queries (Docker Hub / ECR / GCR) for connector version
+# discovery. When false, /versions and /spec return DEFAULT_CONNECTOR_VERSION
+# instead of polling the registry.
+CONNECTOR_DISCOVERY_ENABLED: true
+
+# Fallback connector version used when CONNECTOR_DISCOVERY_ENABLED is false.
+# Ignored when discovery is enabled. Example: "v0.3.18".
+DEFAULT_CONNECTOR_VERSION: ""
+
 # Prefer setting this via environment.
 OLAKE_SECRET_KEY: ""
 

--- a/server/internal/appconfig/appconfig.go
+++ b/server/internal/appconfig/appconfig.go
@@ -35,6 +35,17 @@ type Config struct {
 	OptimizationBaseURL   string
 	OptimizationUsername  string
 	OptimizationPassword  string
+
+	// ConnectorDiscoveryEnabled controls whether the server queries the
+	// upstream container registry (Docker Hub / ECR / GCR Artifact Registry)
+	// to enumerate available connector image tags. Defaults to true.
+	// Disable in Fusion-only or air-gapped deployments that don't need
+	// CDC connector discovery and want to avoid registry rate limits.
+	ConnectorDiscoveryEnabled bool
+
+	// DefaultConnectorVersion is returned by /versions and used by /spec
+	// when ConnectorDiscoveryEnabled is false. Ignored when discovery is on.
+	DefaultConnectorVersion string
 }
 
 var cfg = loadConfig()
@@ -93,5 +104,8 @@ func loadConfig() Config {
 		OptimizationBaseURL:  strings.TrimSpace(v.GetString("OPTIMIZATION_BASE_URL")),
 		OptimizationUsername: strings.TrimSpace(v.GetString("USERNAME")),
 		OptimizationPassword: strings.TrimSpace(v.GetString("PASSWORD")),
+
+		ConnectorDiscoveryEnabled: v.GetBool("CONNECTOR_DISCOVERY_ENABLED"),
+		DefaultConnectorVersion:   strings.TrimSpace(v.GetString("DEFAULT_CONNECTOR_VERSION")),
 	}
 }

--- a/server/internal/utils/docker_utils.go
+++ b/server/internal/utils/docker_utils.go
@@ -73,8 +73,24 @@ func GetWorkerEnvVars() map[string]string {
 
 // GetDriverImageTags returns image tags from ECR, Artifact Registry, or Docker Hub with fallback to cached images
 func GetDriverImageTags(ctx context.Context, imageName string, cachedTags bool) ([]string, string, error) {
+	cfg := appconfig.Load()
+
+	// Short-circuit when connector discovery is disabled (e.g. Fusion-only or
+	// air-gapped deployments). Return the configured default version without
+	// contacting any container registry.
+	if !cfg.ConnectorDiscoveryEnabled {
+		if cfg.DefaultConnectorVersion == "" {
+			return nil, "", fmt.Errorf("connector discovery is disabled (CONNECTOR_DISCOVERY_ENABLED=false) and DEFAULT_CONNECTOR_VERSION is unset")
+		}
+		driverImage := imageName
+		if driverImage == "" {
+			driverImage = defaultImages[0]
+		}
+		return []string{cfg.DefaultConnectorVersion}, strings.TrimPrefix(driverImage, "olakego/source-"), nil
+	}
+
 	// TODO: make constants file and validate all env vars in start of server
-	repositoryBase := appconfig.Load().ContainerRegistryBase
+	repositoryBase := cfg.ContainerRegistryBase
 	if repositoryBase == "" {
 		return nil, "", fmt.Errorf("failed to get CONTAINER_REGISTRY_BASE")
 	}
@@ -100,7 +116,7 @@ func GetDriverImageTags(ctx context.Context, imageName string, cachedTags bool) 
 		// Fallback to cached if online fetch fails or explicitly requested
 		if err != nil && cachedTags {
 			if constants.ExecutorEnvironment == "kubernetes" {
-				logger.Warn("failed to fetch image tags online for %s: %s. Cached fallback unavailable on Kubernetes (no Docker daemon)", imageName, err)
+				logger.Warn("failed to fetch image tags online for %s: %s. No local image cache is available on Kubernetes; set CONNECTOR_DISCOVERY_ENABLED=false with DEFAULT_CONNECTOR_VERSION to skip registry queries if connectors are unused", imageName, err)
 				continue
 			}
 			logger.Warn("failed to fetch image tags online for %s: %s, falling back to cached tags", imageName, err)


### PR DESCRIPTION
## Summary

Closes part of #380.

Adds a new server config flag `CONNECTOR_DISCOVERY_ENABLED` (default `true`) that, when disabled, short-circuits `utils.GetDriverImageTags` and returns a configurable `DEFAULT_CONNECTOR_VERSION` instead of querying Docker Hub / ECR / GCR Artifact Registry. Default-on preserves the current behavior for every existing deployment.

This addresses the Fusion-only / air-gapped use case described in #380, where the UI hits Docker Hub on every `/versions`, `/spec`, and `/test-connection` call even though CDC connectors are unused. With discovery disabled, those endpoints return the configured version without an outbound HTTP request, eliminating both the user-facing slowness during rate-limited periods and the log noise.

This is suggestion (1) from the issue. Suggestion (5) (rewording the K8s warning) is bundled here since it's a one-liner and naturally points operators at the new flag. Suggestions (2) backoff, (3) DB spec cache, and (4) custom discovery registry are intentionally out of scope.

## Changes

- `server/internal/appconfig/appconfig.go` — two new fields on `Config`: `ConnectorDiscoveryEnabled` (bool) and `DefaultConnectorVersion` (string).
- `server/conf/app.yaml` — defaults: `CONNECTOR_DISCOVERY_ENABLED: true`, `DEFAULT_CONNECTOR_VERSION: ""`. Behavior unchanged unless an operator explicitly opts in.
- `server/internal/utils/docker_utils.go` — `GetDriverImageTags` short-circuits at the top of the function when discovery is disabled; returns `(nil, "", error)` with a clear message if `DEFAULT_CONNECTOR_VERSION` is unset.
- `server/internal/utils/docker_utils.go` — rewords the Kubernetes "Cached fallback unavailable on Kubernetes (no Docker daemon)" warning at line 103 to be less alarming and to mention the new flag.

## Helm chart

A separate docs-only PR to `datazip-inc/olake-helm` will surface the flag via `olakeUI.env` examples + a README note. No template change is required there because `olakeUI.env` is already a passthrough map.

## Operator usage

```yaml
# values.yaml
olakeUI:
  env:
    CONNECTOR_DISCOVERY_ENABLED: "false"
    DEFAULT_CONNECTOR_VERSION: "v0.3.18"
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Manual: verify default (`CONNECTOR_DISCOVERY_ENABLED=true`) preserves existing `/versions` and `/spec` behavior
- [ ] Manual: verify `CONNECTOR_DISCOVERY_ENABLED=false` with `DEFAULT_CONNECTOR_VERSION=v0.3.18` makes `/versions` return `["v0.3.18"]` without any outbound HTTP
- [ ] Manual: verify `CONNECTOR_DISCOVERY_ENABLED=false` with empty `DEFAULT_CONNECTOR_VERSION` returns a clear error on `/versions` and `/spec`