### PR TITLE
chore: suppress govulncheck stdlib findings until Go 1.25.11 is available

### DIFF
--- a/.govulnignore
+++ b/.govulnignore
@@ -1,0 +1,6 @@
+# TODO: Remove all entries below once Go 1.25.11 is available in https://storage.googleapis.com/golang/go1.25.11.linux-amd64.tar.gz
+#
+# GO-2026-5037: Inefficient candidate hostname parsing in crypto/x509
+GO-2026-5037
+# GO-2026-5039: Arbitrary inputs are included in errors without any escaping in net/textproto
+GO-2026-5039


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds `.govulnignore` so security CI passes while the project stays on Go **1.25.10.** Govulncheck reports three standard-library issues (GO-2026-5037, GO-2026-5039) that are fixed in Go **1.25.11**, but that toolchain is not yet installable from Google’s download servers in CI.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
