### PR TITLE
fix: ambiguity when catalog and database names are same

### DIFF
--- a/server/internal/constants/constants.go
+++ b/server/internal/constants/constants.go
@@ -108,7 +108,7 @@ var (
 	OptFullCron            = "self-optimizing.full.trigger.cron"
 	OptTargetFileSize      = "self-optimizing.target-size"
 	OptEnableOptimization  = "self-optimizing.enabled"
-	OptSQLCommand          = "ALTER TABLE %s.%s SET TBLPROPERTIES (%s)"
+	OptSQLCommand          = "ALTER TABLE %s.%s.%s SET TBLPROPERTIES (%s)"
 	// properties
 	OptCreatedAt    = "created-at"
 	OptCacheEnabled = "cache-enabled"

--- a/server/internal/services/optimization/terminal.go
+++ b/server/internal/services/optimization/terminal.go
@@ -54,7 +54,7 @@ func (s *Service) SetTableProperties(ctx context.Context, req dto.SetTableProper
 		propsSQL = append(propsSQL, fmt.Sprintf("'%s' = '%s'", key, value))
 	}
 
-	sql := fmt.Sprintf(constants.OptSQLCommand, req.Database, req.Table, strings.Join(propsSQL, ", "))
+	sql := fmt.Sprintf(constants.OptSQLCommand, req.Catalog, req.Database, req.Table, strings.Join(propsSQL, ", "))
 
 	// execute via Terminal API
 	path := fmt.Sprintf(constants.OptPathTerminalExecute, req.Catalog)


### PR DESCRIPTION
## Description

Fixes compaction toggle and optimization config not applying when catalog and database share the same name.

olake-ui was generating a 2-part `ALTER TABLE {database}.{table}` SQL via Fusion's Spark terminal. When catalog and database names match, Spark resolves `{name}.{table}` as catalog + table instead of namespace + table, causing:

```
AnalysisException: [TABLE_OR_VIEW_NOT_FOUND]
The table or view `{catalog}`.`{table}` cannot be found.
```

Updated SQL to use the 3-part identifier: `ALTER TABLE {catalog}.{database}.{table} SET TBLPROPERTIES (...)`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Catalog name ≠ database name — compaction toggle enables successfully
- [x] Catalog name = database name — compaction toggle enables successfully (previously failed silently)

Have checked backward compatibility as have upgraded a failing deployment by changing the image with the latest changes.

# Screenshots or Recordings
<!-- N/A -->

## Related PR's (If Any):
<!-- N/A -->