### PR TITLE
feat: store target query engines and pass them to discover

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -1886,7 +1886,7 @@ const docTemplate = `{
         },
         "/api/v1/project/{projectid}/sources/spec": {
             "post": {
-                "description": "Retrieve the UI spec for a specific source type/version.",
+                "description": "Retrieve the UI spec for a specific source type/version, or the supported query engines when available_query_engines is set.",
                 "tags": [
                     "Sources"
                 ],
@@ -2971,6 +2971,17 @@ const docTemplate = `{
                 "max_discover_threads": {
                     "type": "integer",
                     "example": 50
+                },
+                "target_query_engines": {
+                    "description": "TargetQueryEngines are the engines expected to read the destination tables. OLake\nkeeps them nowhere, so they are stored here and resent on every discover; changing\nthem requires regenerating the catalog to recompute available_update_types.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "spark",
+                        "duckdb"
+                    ]
                 }
             }
         },
@@ -3664,6 +3675,11 @@ const docTemplate = `{
                 "version"
             ],
             "properties": {
+                "available_query_engines": {
+                    "description": "AvailableQueryEngines swaps the connector UI spec for the query engines the connector\nsupports and the delete formats each can read. The response carries a null spec on\nconnector versions that predate the feature.",
+                    "type": "boolean",
+                    "example": false
+                },
                 "type": {
                     "description": "enum: postgres,mongodb,mysql,mssql,db2,s3,kafka,iceberg",
                     "type": "string",
@@ -3740,6 +3756,17 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "example": "my-postgres-source"
+                },
+                "target_query_engines": {
+                    "description": "TargetQueryEngines are the engines expected to read the destination tables. OLake\nturns them into each stream's available_update_types; it stores nothing else, so the\nselection must be sent on every discover to stay applied.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "spark",
+                        "duckdb"
+                    ]
                 },
                 "type": {
                     "type": "string",

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1877,7 +1877,7 @@
         },
         "/api/v1/project/{projectid}/sources/spec": {
             "post": {
-                "description": "Retrieve the UI spec for a specific source type/version.",
+                "description": "Retrieve the UI spec for a specific source type/version, or the supported query engines when available_query_engines is set.",
                 "tags": [
                     "Sources"
                 ],
@@ -2962,6 +2962,17 @@
                 "max_discover_threads": {
                     "type": "integer",
                     "example": 50
+                },
+                "target_query_engines": {
+                    "description": "TargetQueryEngines are the engines expected to read the destination tables. OLake\nkeeps them nowhere, so they are stored here and resent on every discover; changing\nthem requires regenerating the catalog to recompute available_update_types.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "spark",
+                        "duckdb"
+                    ]
                 }
             }
         },
@@ -3655,6 +3666,11 @@
                 "version"
             ],
             "properties": {
+                "available_query_engines": {
+                    "description": "AvailableQueryEngines swaps the connector UI spec for the query engines the connector\nsupports and the delete formats each can read. The response carries a null spec on\nconnector versions that predate the feature.",
+                    "type": "boolean",
+                    "example": false
+                },
                 "type": {
                     "description": "enum: postgres,mongodb,mysql,mssql,db2,s3,kafka,iceberg",
                     "type": "string",
@@ -3731,6 +3747,17 @@
                 "name": {
                     "type": "string",
                     "example": "my-postgres-source"
+                },
+                "target_query_engines": {
+                    "description": "TargetQueryEngines are the engines expected to read the destination tables. OLake\nturns them into each stream's available_update_types; it stores nothing else, so the\nselection must be sent on every discover to stay applied.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "spark",
+                        "duckdb"
+                    ]
                 },
                 "type": {
                     "type": "string",

--- a/server/internal/constants/constants.go
+++ b/server/internal/constants/constants.go
@@ -30,6 +30,8 @@ var (
 	DefaultSpecVersion               = "v0.2.0"
 	DefaultClearDestinationVersion   = "v0.3.0"
 	DefaultMaxDiscoverThreadsVersion = "v0.3.18"
+	// DefaultQueryEnginesVersion is the first release with the query engine flags; older images reject them.
+	DefaultQueryEnginesVersion = "v0.10.2"
 
 	// logging
 	EnvLogLevel          = "LOG_LEVEL"
@@ -41,6 +43,8 @@ var (
 
 	// command flags
 	MaxDiscoverThreadsFlag    = "--max-discover-threads"
+	AvailableQueryEnginesFlag = "--available-query-engines"
+	TargetQueryEnginesFlag    = "--target-query-engines"
 	DefaultMaxDiscoverThreads = 50
 
 	// conf keys

--- a/server/internal/handlers/etl/source.go
+++ b/server/internal/handlers/etl/source.go
@@ -287,7 +287,7 @@ func (h *Handler) GetSourceVersions(c *gin.Context) {
 
 // @Summary Get source UI spec
 // @Tags Sources
-// @Description Retrieve the UI spec for a specific source type/version.
+// @Description Retrieve the UI spec for a specific source type/version, or the supported query engines when available_query_engines is set.
 // @Param   projectid     path    string  true    "project id (default is 123)"
 // @Param   body          body    dto.SpecRequest true "spec request data"
 // @Success 200 {object} dto.JSONResponse{data=dto.SpecResponse}

--- a/server/internal/models/dto/requests.go
+++ b/server/internal/models/dto/requests.go
@@ -30,6 +30,8 @@ type SpecRequest struct {
 	// enum: postgres,mongodb,mysql,mssql,db2,s3,kafka,iceberg
 	Type    string `json:"type" binding:"required" example:"postgres"`
 	Version string `json:"version" binding:"required" example:"v0.2.7"`
+	// AvailableQueryEngines swaps the UI spec for the engine matrix; the spec is null on older connectors.
+	AvailableQueryEngines bool `json:"available_query_engines,omitempty" example:"false"`
 }
 
 // check unique job name request
@@ -52,6 +54,8 @@ type StreamsRequest struct {
 	MaxDiscoverThreads *int   `json:"max_discover_threads,omitempty" example:"50"`
 	JobID              int    `json:"job_id" binding:"required" example:"1"`
 	JobName            string `json:"job_name" binding:"required" example:"my-sync-job"`
+	// TargetQueryEngines become each stream's available_update_types; OLake stores none, so resend every discover.
+	TargetQueryEngines []string `json:"target_query_engines,omitempty" example:"spark,duckdb"`
 }
 
 // TODO: frontend needs to send only version no need for source version
@@ -96,6 +100,8 @@ type AdvancedSettings struct {
 	// IndexRequired is derived by the UI: true when any selected stream upserts
 	// with positional deletes.
 	IndexRequired *bool `json:"index_required,omitempty" example:"true"`
+	// TargetQueryEngines are stored here because OLake keeps none; changing them needs the catalog regenerated.
+	TargetQueryEngines []string `json:"target_query_engines,omitempty" example:"spark,duckdb"`
 }
 
 type CreateJobRequest struct {

--- a/server/internal/services/etl/destination.go
+++ b/server/internal/services/etl/destination.go
@@ -267,7 +267,8 @@ func (s Service) GetDestinationSpec(ctx context.Context, req *dto.SpecRequest) (
 		return dto.SpecResponse{}, fmt.Errorf("failed to get driver image tags: %s", err)
 	}
 
-	specOut, err := s.temporal.GetDriverSpecs(ctx, req.Type, driver, req.Version)
+	// The matrix describes engines, not destinations, so this endpoint always serves the destination UI spec.
+	specOut, err := s.temporal.GetDriverSpecs(ctx, req.Type, driver, req.Version, false)
 	if err != nil {
 		return dto.SpecResponse{}, fmt.Errorf("failed to get spec: %s", err)
 	}

--- a/server/internal/services/etl/source.go
+++ b/server/internal/services/etl/source.go
@@ -265,6 +265,7 @@ func (s Service) GetSourceCatalog(ctx context.Context, req *dto.StreamsRequest) 
 		oldStreams,
 		req.JobName,
 		req.MaxDiscoverThreads,
+		req.TargetQueryEngines,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog: %s", err)
@@ -285,7 +286,7 @@ func (s Service) GetSourceVersions(ctx context.Context, sourceType string) (dto.
 
 // TODO: cache spec in db for each version
 func (s Service) GetSourceSpec(ctx context.Context, req *dto.SpecRequest) (dto.SpecResponse, error) {
-	specOut, err := s.temporal.GetDriverSpecs(ctx, "", req.Type, req.Version)
+	specOut, err := s.temporal.GetDriverSpecs(ctx, "", req.Type, req.Version, req.AvailableQueryEngines)
 	if err != nil {
 		return dto.SpecResponse{}, fmt.Errorf("failed to get spec: %s", err)
 	}

--- a/server/internal/services/temporal/execute.go
+++ b/server/internal/services/temporal/execute.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/datazip-inc/olake-ui/server/internal/appconfig"
@@ -67,7 +68,7 @@ const (
 // ref: https://docs.temporal.io/troubleshooting/blob-size-limit-error
 
 // DiscoverStreams runs a workflow to discover catalog data
-func (t *Temporal) DiscoverStreams(ctx context.Context, sourceType, version, config, streamsConfig, jobName string, maxDiscoverThreads *int) (map[string]interface{}, error) {
+func (t *Temporal) DiscoverStreams(ctx context.Context, sourceType, version, config, streamsConfig, jobName string, maxDiscoverThreads *int, targetQueryEngines []string) (map[string]interface{}, error) {
 	workflowID := fmt.Sprintf("discover-catalog-%s-%d", sourceType, time.Now().Unix())
 
 	configs := []JobConfig{
@@ -101,6 +102,11 @@ func (t *Temporal) DiscoverStreams(ctx context.Context, sourceType, version, con
 
 	if streamsConfig != "" {
 		cmdArgs = append(cmdArgs, "--catalog", "/mnt/config/streams.json")
+	}
+
+	// OLake stores no engines, so an omitted flag means unconstrained rather than "reuse the last choice".
+	if len(targetQueryEngines) > 0 && supportsQueryEngines(version) {
+		cmdArgs = append(cmdArgs, constants.TargetQueryEnginesFlag, strings.Join(targetQueryEngines, ","))
 	}
 
 	if encryptionKey := appconfig.Load().EncryptionKey; encryptionKey != "" {
@@ -138,7 +144,12 @@ func (t *Temporal) DiscoverStreams(ctx context.Context, sourceType, version, con
 }
 
 // FetchSpec runs a workflow to fetch driver specifications
-func (t *Temporal) GetDriverSpecs(ctx context.Context, destinationType, sourceType, version string) (dto.SpecOutput, error) {
+func (t *Temporal) GetDriverSpecs(ctx context.Context, destinationType, sourceType, version string, availableQueryEngines bool) (dto.SpecOutput, error) {
+	// An older image rejects the flag and fails the workflow, so report the feature as absent instead.
+	if availableQueryEngines && !supportsQueryEngines(version) {
+		return dto.SpecOutput{}, nil
+	}
+
 	workflowID := fmt.Sprintf("fetch-spec-%s-%d", sourceType, time.Now().Unix())
 
 	// spec version >= DefaultSpecVersion is required
@@ -149,7 +160,10 @@ func (t *Temporal) GetDriverSpecs(ctx context.Context, destinationType, sourceTy
 	cmdArgs := []string{
 		"spec",
 	}
-	if destinationType != "" {
+	// Exclusive: --available-query-engines exits before any spec file resolves, ignoring --destination-type.
+	if availableQueryEngines {
+		cmdArgs = append(cmdArgs, constants.AvailableQueryEnginesFlag)
+	} else if destinationType != "" {
 		cmdArgs = append(cmdArgs, "--destination-type", destinationType)
 	}
 
@@ -183,6 +197,11 @@ func (t *Temporal) GetDriverSpecs(ctx context.Context, destinationType, sourceTy
 	return dto.SpecOutput{
 		Spec: result,
 	}, nil
+}
+
+// supportsQueryEngines reports whether the version takes the engine flags; custom builds are assumed current.
+func supportsQueryEngines(version string) bool {
+	return utils.GetCustomDriverVersion() != "" || semver.Compare(version, constants.DefaultQueryEnginesVersion) >= 0
 }
 
 // TestConnection runs a workflow to test connection


### PR DESCRIPTION
# Description
Server support for the target query engines .

- `advanced_settings.target_query_engines` stores the engine selection on the job,
  the same path `max_discover_threads` takes. No migration — the column is jsonb.
- `StreamsRequest.target_query_engines` becomes `--target-query-engines` on discover,
  where OLake turns it into each stream's `available_update_types`.
- `available_query_engines` on the spec request returns the engine matrix the CLI
  ships, so the UI never carries its own copy.

Both flags are gated on `DefaultQueryEnginesVersion`; older images reject them as
unknown flags, so the spec call returns a null spec and the discover flag is omitted.

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
